### PR TITLE
Update to metlog 0.9 API.

### DIFF
--- a/dev-reqs.txt
+++ b/dev-reqs.txt
@@ -37,7 +37,7 @@ gevent==0.13.7
 pylibmc==1.2.2
 requests==0.11.1
 chardet==1.0.1
-metlog-py==0.8.4
+metlog-py==0.9
 wimms==0.2
 powerhose==0.5
 tokenlib==0.1

--- a/prod-reqs.txt
+++ b/prod-reqs.txt
@@ -37,7 +37,7 @@ gevent==0.13.7
 pylibmc==1.2.2
 requests==0.11.1
 chardet==1.0.1
-metlog-py==0.8.4
+metlog-py==0.9
 wimms==0.2
 powerhose==0.5
 tokenlib==0.1

--- a/tokenserver/__init__.py
+++ b/tokenserver/__init__.py
@@ -6,7 +6,8 @@ from ConfigParser import NoSectionError
 from collections import defaultdict
 
 from tokenserver.assignment import INodeAssignment
-from tokenserver.util import hook_metlog_handler
+
+from metlog.logging import hook_logger
 
 from mozsvc.config import get_configurator
 from mozsvc.plugin import load_and_register, load_from_settings
@@ -41,7 +42,7 @@ def includeme(config):
 
     if settings['metlog.enabled']:
         for logger in ('tokenserver', 'mozsvc', 'powerhose'):
-            hook_metlog_handler(metlog_wrapper.client, logger)
+            hook_logger(logger, metlog_wrapper.client)
 
     config.registry['metlog'] = metlog_wrapper.client
 

--- a/tokenserver/crypto/master.py
+++ b/tokenserver/crypto/master.py
@@ -45,17 +45,6 @@ def get_metlog():
     return get_current_registry()['metlog']
 
 
-class _FakeTimer(object):
-    timestamp = None
-    logger = None
-    severity = None
-    name = 'token.powerhose'
-    rate = 1.0
-    fields = None
-
-_fake_timer = _FakeTimer
-
-
 class PowerHoseRunner(object):
     """Implements a simple powerhose runner.
 
@@ -105,7 +94,7 @@ class PowerHoseRunner(object):
             return self.pool.execute(data)
         finally:
             duration = time.time() - start
-            self.metlog.timing(_fake_timer, duration)
+            self.metlog.timer_send("token.powerhose", duration)
 
     def __getattr__(self, attr):
         """magic method getter to be able to do direct function calls on this

--- a/tokenserver/tests/test_powerhose.py
+++ b/tokenserver/tests/test_powerhose.py
@@ -24,7 +24,8 @@ from tokenserver.tests.support import (
     get_assertion,
     unittest,
 )
-from tokenserver.util import hook_metlog_handler
+
+from metlog.loggimg import hook_logger
 
 from browserid.errors import InvalidSignatureError
 
@@ -77,7 +78,7 @@ class TestPowerService(unittest.TestCase):
         metlog_wrapper = load_from_settings('metlog',
                 cls.config.registry.settings)
         for logger in ('tokenserver', 'mozsvc', 'powerhose'):
-            hook_metlog_handler(metlog_wrapper.client, logger)
+            hook_logger(logger, metlog_wrapper.client)
         cls.config.registry['metlog'] = metlog_wrapper.client
         cls.config.include("tokenserver")
         load_and_register("tokenserver", cls.config)

--- a/tokenserver/tests/test_service.py
+++ b/tokenserver/tests/test_service.py
@@ -10,7 +10,8 @@ from cornice.tests import CatchErrors
 from mozsvc.config import load_into_settings
 from mozsvc.plugin import load_and_register, load_from_settings
 
-from tokenserver.util import hook_metlog_handler
+from metlog.logging import hook_logger
+
 from tokenserver.assignment import INodeAssignment
 from browserid.tests.support import (
     make_assertion,
@@ -36,7 +37,7 @@ class TestService(unittest.TestCase):
         metlog_wrapper = load_from_settings('metlog',
                 self.config.registry.settings)
         for logger in ('tokenserver', 'mozsvc', 'powerhose'):
-            hook_metlog_handler(metlog_wrapper.client, logger)
+            hook_logger(logger, metlog_wrapper.client)
 
         self.config.registry['metlog'] = metlog_wrapper.client
         self.config.include("tokenserver")

--- a/tokenserver/util.py
+++ b/tokenserver/util.py
@@ -78,31 +78,3 @@ def display_secrets(filename, node=None):
 
 def get_logger():
     return get_current_registry()['metlog']
-
-
-class MetlogHandler(logging.Handler):
-    def __init__(self, metlog):
-        logging.Handler.__init__(self)
-        self.metlog = metlog
-
-    def emit(self, record):
-        if record.levelno == logging.DEBUG:
-            severity = SEVERITY.DEBUG
-        elif record.levelno == logging.INFO:
-            severity = SEVERITY.INFORMATIONAL
-        elif record.levelno == logging.WARNING:
-            severity = SEVERITY.WARNING
-        elif record.levelno == logging.ERROR:
-            severity = SEVERITY.ERROR
-        else:   # critical
-            severity = SEVERITY.CRITICAL
-
-        self.metlog.metlog(type='oldstyle', severity=severity,
-                    payload=record.msg)
-
-
-def hook_metlog_handler(metlog, name):
-    logger = logging.getLogger(name)
-    handler = MetlogHandler(metlog)
-    handler.setLevel(logging.DEBUG)
-    logger.addHandler(handler)

--- a/tokenserver/views.py
+++ b/tokenserver/views.py
@@ -135,17 +135,6 @@ def pattern_exists(request):
     request.validated['pattern'] = pattern
 
 
-class _FakeTimer(object):
-    timestamp = None
-    logger = None
-    severity = None
-    name = 'token.sql.allocate_node'
-    rate = 1.0
-    fields = None
-
-_fake_timer = _FakeTimer
-
-
 @token.get(validators=(valid_app, valid_assertion, pattern_exists))
 def return_token(request):
     """This service does the following process:
@@ -179,7 +168,7 @@ def return_token(request):
             uid, node = backend.allocate_node(email, service)
         finally:
             duration = time.time() - start
-            metlog.timing(_fake_timer, duration)
+            metlog.timer_send("token.sql.allocate_node", duration)
 
     secrets = request.registry.settings['tokenserver.secrets_file']
     node_secrets = secrets.get(node)


### PR DESCRIPTION
The latest metlog has some breaking API changes, hopefully this catches them all.  This is patch in place, I can successfully run tokenserver and server-syncstorage in the same process using metlog-py 0.9.
