### PR TITLE
Update PyMySQL monkey-patching for compatibility with latest release.

### DIFF
--- a/tokenserver/assignment/sqlnode.py
+++ b/tokenserver/assignment/sqlnode.py
@@ -15,18 +15,13 @@ from tokenserver.util import get_logger
 # try to have this changed upstream:
 # XXX being able to set autocommit=1;
 # forcing it for now
-from pymysql.connections import Connection, COM_QUERY
+from pymysql.connections import Connection
 
+
+orig_autocommit = Connection.autocommit
 
 def autocommit(self, value):
-    value = True
-    try:
-        self._execute_command(COM_QUERY, "SET AUTOCOMMIT = %s" % \
-                                    self.escape(value))
-        self.read_packet()
-    except:
-        exc, value, __ = sys.exc_info()
-        self.errorhandler(None, exc, value)
+    return orig_autocommit(self, True)
 
 Connection.autocommit = autocommit
 


### PR DESCRIPTION
The details of PyMySQL.Connection.autocommit have changed in the latest upstream release, this updates our monkey-patching of that method for compatibility.
