### PR TITLE
Report a special error code when assertion has a bad timestamp.

### DIFF
--- a/tokenserver/__init__.py
+++ b/tokenserver/__init__.py
@@ -32,6 +32,7 @@ def includeme(config):
 
     config.include("cornice")
     config.include("mozsvc")
+    config.include("tokenserver.tweens")
     config.scan("tokenserver.views")
     settings = config.registry.settings
 

--- a/tokenserver/tests/test_fixednode.ini
+++ b/tokenserver/tests/test_fixednode.ini
@@ -18,7 +18,7 @@ aitc-1.0 = {node}/1.0/{uid}
 [browserid]
 backend = tokenserver.verifiers.LocalVerifier
 warning = False
-audiences = *
+audiences = http://tokenserver.services.mozilla.com
 
 # Paster configuration for Pyramid
 [filter:catcherror]

--- a/tokenserver/tweens.py
+++ b/tokenserver/tweens.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import time
+import random
+
+from pyramid.httpexceptions import HTTPException, HTTPServiceUnavailable
+
+
+def set_x_timestamp_header(handler, registry):
+    """Tween to set the X-Timestamp header on all responses."""
+
+    def set_x_timestamp_header_tween(request):
+        try:
+            response = handler(request)
+        except HTTPException, response:
+            response.headers["X-Timestamp"] = str(int(time.time()))
+            raise
+        else:
+            response.headers["X-Timestamp"] = str(int(time.time()))
+            return response
+
+    return set_x_timestamp_header_tween
+
+
+def includeme(config):
+    """Include all the TokenServer tweens into the given config."""
+    config.add_tween("tokenserver.tweens.set_x_timestamp_header")


### PR DESCRIPTION
This implements a special error status for invalid-timestamp, as requested in #17.  It also lays the groundwork for reporting invalid-generation errors as documented in https://bugzilla.mozilla.org/show_bug.cgi?id=958462

I had to drop the use of cornice_error helper in order to customize the 'status' field; we should look at syncing this into upstream cornice at some point, per discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=792674.  But getting this live needs to take priority.

@ametaireau r?
