### PR TITLE
configure PyBrowserId's SupportDocumentManager from syncserver.ini

### DIFF
--- a/tokenserver/verifiers.py
+++ b/tokenserver/verifiers.py
@@ -10,6 +10,7 @@ from browserid.verifiers.local import LocalVerifier as LocalVerifier_
 from browserid.errors import (InvalidSignatureError, ExpiredSignatureError,
                               ConnectionError, AudienceMismatchError,
                               InvalidIssuerError)
+from browserid.supportdoc import SupportDocumentManager
 
 
 def get_verifier(registry=None):
@@ -28,6 +29,15 @@ class IBrowserIdVerifier(Interface):
 # The default verifier from browserid
 class LocalVerifier(LocalVerifier_):
     implements(IBrowserIdVerifier)
+    def __init__(self,  **kwargs):
+        # to set verify to False if configured so
+        if 'verify' in kwargs:
+            verify=kwargs["verify"]
+            kwargs.pop("verify")
+        else:
+            verify=None
+        kwargs['supportdocs'] = SupportDocumentManager(verify=verify)
+        super(LocalVerifier, self).__init__(**kwargs)
 
 
 # A verifier that posts to a remote verifier service.


### PR DESCRIPTION
This is a first attempt at addressing a local deployment of fxa-auth-server and syncserver:
the auth-server will use a self signed certificate so if local browserid verifiers checks the https certificate, it fails.
So I add the ability to disable verify. A better fix is to add the local certificate as trusted for requests down in PyBrowserId, but I don't know how, yet.
add this section to syncserver.ini to enable local https deployment for local testing of firefox sync:
[browserid]
backend = tokenserver.verifiers.LocalVerifier
audiences = *
verify = False
