### PR TITLE
add fxa uid and device_id to tokens

### DIFF
--- a/tokenserver/__init__.py
+++ b/tokenserver/__init__.py
@@ -70,7 +70,11 @@ def includeme(config):
 
     # ensure the metrics_id_secret_key is an ascii string.
     id_key = settings.get('fxa.metrics_uid_secret_key')
-    if id_key is not None and isinstance(id_key, unicode):
+    if id_key is None:
+        logger.warning(
+            'fxa.metrics_uid_secret_key is not set. '
+            'This will allow PII to be more easily identified')
+    elif isinstance(id_key, unicode):
         settings['fxa.metrics_uid_secret_key'] = id_key.encode('ascii')
 
     read_endpoints(config)

--- a/tokenserver/util.py
+++ b/tokenserver/util.py
@@ -54,14 +54,15 @@ def hash_email(email):
     return b32encode(digest).lower()
 
 
-def fxa_metrics_uid(email, hmac_key):
-    """Derive FxA metrics id from user's FxA email address.
+def fxa_metrics_hash(value, hmac_key):
+    """Derive FxA metrics id from user's FxA email address or whatever.
 
-    This is used to obfuscate the FxA id before logging it with the metrics
+    This is used to obfuscate the id before logging it with the metrics
     data, as a simple privacy measure.
     """
     hasher = hmac.new(hmac_key, '', sha256)
-    hasher.update(email.split("@", 1)[0])
+    # value may be an email address, in which case we only want the first part
+    hasher.update(value.split("@", 1)[0])
     return hasher.hexdigest()
 
 


### PR DESCRIPTION
This change adds `fxa_uid` and `device_id` to the generated token as well as logging them for metrics.

For `device_id` it relies on the new `fxa-deviceId` claim from FxA coming in v1.57. When not present it will be a hash of `fxa_uid + 'none'`.