### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/tokenserver/assignment/sqlnode/migrations/README
+++ b/tokenserver/assignment/sqlnode/migrations/README
@@ -4,5 +4,5 @@ Database migrations for WIMMS.
 This directory contains alembic migrations tracking the database schema
 changes made in WIMMS:
 
-  http://alembic.readthedocs.org/
+  https://alembic.readthedocs.io/
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.