### PR TITLE
Reduce docker image size from 776.5MB => 283.7MB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,7 @@
 .git
+docs
+bin
+include
+lib
+local
+man

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.11
+FROM python:2.7-slim
 
 RUN groupadd --gid 1001 app && \
     useradd --uid 1001 --gid 1001 --shell /usr/sbin/nologin app
@@ -7,8 +7,13 @@ WORKDIR /app
 COPY ./requirements.txt /app/requirements.txt
 
 # install tokenserver dependencies
-RUN pip install --upgrade --no-cache-dir -r requirements.txt \
-        gunicorn nose flake8
+RUN apt-get -q update \
+    && apt-get -q --yes install g++ \
+    && pip install --upgrade --no-cache-dir -r requirements.txt \
+         gunicorn nose flake8 \
+    && apt-get -q --yes remove g++ \
+    && apt-get -q --yes autoremove \
+    && apt-get clean
 
 COPY . /app
 RUN python ./setup.py develop


### PR DESCRIPTION
- change base to python:2.7-slim
- remove g++ package and deps when using pip

@rfk r? please