### PR TITLE
Return a distinct error when rejecting a new user with otherwise valid credentials

### DIFF
--- a/tokenserver/tests/test_service.py
+++ b/tokenserver/tests/test_service.py
@@ -378,7 +378,7 @@ class TestService(unittest.TestCase):
         assertion = self._getassertion(email="newuser3@test.com")
         headers = {'Authorization': 'BrowserID %s' % assertion}
         res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
-        self.assertEqual(res.json['status'], 'invalid-credentials')
+        self.assertEqual(res.json['status'], 'new-users-disabled')
         # But existing users are still allowed.
         assertion = self._getassertion(email="newuser1@test.com")
         headers = {'Authorization': 'BrowserID %s' % assertion}

--- a/tokenserver/views.py
+++ b/tokenserver/views.py
@@ -233,7 +233,7 @@ def return_token(request):
     if not user:
         allowed = settings.get('tokenserver.allow_new_users', True)
         if not allowed:
-            raise _unauthorized('invalid-credentials')
+            raise _unauthorized('new-users-disabled')
         with metrics_timer('tokenserver.backend.allocate_user', request):
             user = backend.allocate_user(service, email, generation,
                                          client_state)


### PR DESCRIPTION
Fixes https://github.com/mozilla-services/syncserver/issues/89 for self-hosters; @Natim r?

I'll also update the API docs if/when we merge this.