### PR TITLE
Bug 1455219 - Accept FxA OAuth tokens for authorization.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ notifications:
     use_notice: false
     skip_join: false
 
+before_install:
+  # https://github.com/travis-ci/travis-ci/issues/7940
+  - sudo rm -f /etc/boto.cfg
+
 install:
   - make install-dev
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,6 @@
+-r requirements.txt
 flake8
 mock
 nose
+responses
 webtest

--- a/loadtest/Makefile
+++ b/loadtest/Makefile
@@ -13,6 +13,14 @@ build:
 	$(INSTALL) https://github.com/mozilla-services/loads/archive/master.zip
 	$(INSTALL) -U 'requests<2.13'
 
+# Update https://mock-oauth-stage.dev.lcip.org with latest config.
+mock-oauth-stage:
+	aws cloudformation deploy --template-file ./mock-oauth-cfn.yml --stack-name mock-oauth-stage --capabilities CAPABILITY_IAM
+
+# Run a quick sanity-check on the server's advertised config.
+config-check:
+	../local/bin/loads-runner --config=./config/test.ini --server-url=$(SERVER_URL) loadtest.NodeAssignmentTest.test_server_config
+
 # Run a single test from the local machine, for sanity-checking.
 test:
 	../local/bin/loads-runner --config=./config/test.ini --server-url=$(SERVER_URL) loadtest.NodeAssignmentTest.test_realistic

--- a/loadtest/README.txt
+++ b/loadtest/README.txt
@@ -11,6 +11,22 @@ To run them, you will need the following dependencies:
   * ZeroMQ development files (e.g. libzmq-dev package)
   * (for megabench) ssh access to the mozilla loads cluster
 
+You'll also need to configure the server under test to talk to a mock
+FxA OAuth verifier.  You can use this preconfigured one, which proxies
+valid tokens through to the FxA stage environment:
+
+  https://mock-oauth-stage.dev.lcip.org
+
+Or you can deploy one for your own use using the `mock-oauth-cfn.yml`
+CloudFormation template, like this:
+
+  $> aws cloudformation deploy \
+        --template-file=mock-oauth-cfn.yml \
+        --stack-name my-mock-oauth-stack \
+        --capabilities CAPABILITY_IAM \
+        --parameter-overrides \
+            DomainName=my-mock-oauth.dev.lcip.org
+
 Then do the following:
 
   $> make build       # installs local environment with all dependencies

--- a/loadtest/loadtest.py
+++ b/loadtest/loadtest.py
@@ -1,4 +1,6 @@
 
+import os
+import json
 import time
 import uuid
 import random
@@ -7,6 +9,8 @@ import urlparse
 import browserid
 import browserid.jwt
 from browserid.tests.support import make_assertion
+
+from tokenserver.verifiers import DEFAULT_OAUTH_SCOPE
 
 from loads import TestCase
 
@@ -47,8 +51,14 @@ MOCKMYID_PRIVATE_KEY = browserid.jwt.DS128Key({
 # The below options control what percentage of the requests are each
 # of the other types.
 
-PERCENT_NEW_USER = 0.3  # yes, it really is that low, based on prod traffic
+PERCENT_NEW_USER = 0.3  # point-three of one percent; yes really
 PERCENT_BAD_USER = 1.0
+
+# There are two different authentication mechanisms that can be used,
+# either BrowserID assertions or FxA OAuth tokens.  The below option
+# controls what proportion of requests are the later.
+
+PERCENT_OAUTH = 5.0  # we expect very low OAuth traffic initially
 
 
 class NodeAssignmentTest(TestCase):
@@ -64,9 +74,40 @@ class NodeAssignmentTest(TestCase):
         self.endpoint = urlparse.urljoin(self.server_url, '/1.0/sync/1.5')
         self.audience = self.server_url.rstrip('/')
 
+    def test_server_config(self):
+        """Sanity-check server config against local settings.
+
+        This is a quick test that fetches config from the target server
+        and checks it against our local settings.  It will fail if there's
+        a mis-match that would cause our loatests to fail.
+        """
+        res = self.session.get(self.server_url + '/')
+        self.assertEquals(res.status_code, 200)
+        server_config = res.json()
+        try:
+            allowed_issuers = server_config['browserid']['allowed_issuers']
+            if allowed_issuers is not None:
+                if MOCKMYID_DOMAIN not in allowed_issuers:
+                    msg = 'Server does not allow browserid assertions from {}'
+                    raise AssertionError(msg.format(MOCKMYID_DOMAIN))
+        except KeyError:
+            pass
+        if server_config['oauth']['default_issuer'] != MOCKMYID_DOMAIN:
+            msg = 'OAuth default_issuer does not match {}'
+            raise AssertionError(msg.format(MOCKMYID_DOMAIN))
+        if server_config['oauth']['scope'] != DEFAULT_OAUTH_SCOPE:
+            msg = 'OAuth scope does not match {}'
+            raise AssertionError(msg.format(DEFAULT_OAUTH_SCOPE))
+
     def test_realistic(self):
+        """Run a test scencario based on 'realistic' user behaviour.
+
+        The 'realistic' part depends on correctly configuring the ratio
+        of various kinds of events in the global variables above, to match
+        observed user behaviour in production.
+        """
         if self._flip_a_coin(PERCENT_BAD_USER):
-            self._test_bad_assertion()
+            self._test_bad_auth()
         elif self._flip_a_coin(PERCENT_NEW_USER):
             self._test_new_user()
         else:
@@ -83,11 +124,48 @@ class NodeAssignmentTest(TestCase):
             kwds["issuer_keypair"] = (None, MOCKMYID_PRIVATE_KEY)
         return make_assertion(email, **kwds)
 
-    def _do_token_exchange(self, assertion, status=200):
+    def _make_oauth_token(self, user=None, status=200, **fields):
+        # For mock oauth tokens, we bundle the desired status code
+        # and response body into a JSON blob for the mock verifier
+        # to echo back to us.
+        body = {}
+        if status < 400:
+            if user is None:
+                raise ValueError("Must specify user for valid oauth token")
+            if "scope" not in fields:
+                fields["scope"] = [DEFAULT_OAUTH_SCOPE]
+            if "client_id" not in fields:
+                fields["client_id"] = "x"
+        if user is not None:
+            parts = user.split("@", 1)
+            if len(parts) == 1:
+                body["user"] = user
+            else:
+                body["user"] = parts[0]
+                body["issuer"] = parts[1]
+        body.update(fields)
+        return json.dumps({
+          "status": status,
+          "body": body
+        })
+
+    def _do_token_exchange_via_browserid(self, assertion, status=200):
         headers = {'Authorization': 'BrowserID %s' % assertion}
         res = self.session.get(self.endpoint, headers=headers)
         self.assertEquals(res.status_code, status)
         return res
+
+    def _do_token_exchange_via_oauth(self, token, status=200):
+        headers = {'Authorization': 'Bearer %s' % token}
+        res = self.session.get(self.endpoint, headers=headers)
+        self.assertEquals(res.status_code, status)
+        return res
+
+    def _do_token_exchange(self, email):
+        if self._flip_a_coin(PERCENT_OAUTH):
+            self._do_token_exchange_via_oauth(self._make_oauth_token(email))
+        else:
+            self._do_token_exchange_via_browserid(self._make_assertion(email))
 
     def _test_old_user(self):
         # Get a token for an "existing" user account.
@@ -96,13 +174,19 @@ class NodeAssignmentTest(TestCase):
         # over time.
         uid = random.randint(1, 1000000)
         email = "user{uid}@{host}".format(uid=uid, host=MOCKMYID_DOMAIN)
-        self._do_token_exchange(self._make_assertion(email))
+        self._do_token_exchange(email)
 
     def _test_new_user(self):
         # Get a token for a never-before-seen user account.
         uid = str(uuid.uuid1())
         email = "loadtest-{uid}@{host}".format(uid=uid, host=MOCKMYID_DOMAIN)
-        self._do_token_exchange(self._make_assertion(email))
+        self._do_token_exchange(email)
+
+    def _test_bad_auth(self):
+        if self._flip_a_coin(PERCENT_OAUTH):
+            self._test_bad_oauth_token()
+        else:
+            self._test_bad_assertion()
 
     def _test_bad_assertion(self):
         uid = random.randint(1, 1000000)
@@ -131,7 +215,22 @@ class NodeAssignmentTest(TestCase):
                 "{uid}@{host}".format(uid=uid, host=MOCKMYID_DOMAIN),
                 audience="http://123done.org"
             )
-        self._do_token_exchange(assertion, 401)
+        self._do_token_exchange_via_browserid(assertion, 401)
+
+    def _test_bad_oauth_token(self):
+        uid = random.randint(1, 1000000)
+        # Try to get a token using an invalid OAuth token.
+        # Obviously, this should result in a 401.
+        if self._flip_a_coin(50):
+            # invalid token
+            token = self._make_oauth_token(status=400, errno=108)
+        else:
+            # invalid scope
+            token = self._make_oauth_token(
+                user=str(uid),
+                scope=["unrelated", "scopes"],
+            )
+        self._do_token_exchange_via_oauth(token, 401)
 
     def _flip_a_coin(self, percent=50):
         # Return True on 'percent' percent of calls.

--- a/loadtest/mock-oauth-cfn.yml
+++ b/loadtest/mock-oauth-cfn.yml
@@ -1,0 +1,237 @@
+#
+# This is a CloudFormation script to deploy a tiny lambda+API-gateway
+# service that can mock out FxA OAuth verification responses.
+#
+# When deployed, this API will proxy all HTTP requests through to a live
+# FxA OAuth server, with the following exceptions:
+#
+#  * `GET /config` will return a mocked default issuer.
+#  * `POST /v1/verify` will attempt to parse the submitted token as JSON.
+#     If it succeeds, then it will use the `status` and `body` fields from
+#     that JSON to return a mocked response.
+#
+# The idea is to let this API be used as a stand-in for the real FxA OAuth
+# server, and have it function correctly for manual testing with real accounts,
+# but then also to be able to make fake OAuth tokens during a loadtest, like
+# this:
+#
+#  requests.get("https://mock-oauth-stage.dev.lcip.org", json={
+#      "token": json.dumps({
+#        "status": 200,
+#        "body": {
+#          "user": "loadtest123456",
+#          "scope": ["myscope"],
+#          "client_id": "my_client_id",
+#        }
+#      })
+#  })
+#
+# Or to be able to simulate OAuth token failures like this:
+#
+#  requests.get("https://mock-oauth-stage.dev.lcip.org", json={
+#      "token": json.dumps({
+#        "status": 400,
+#        "body": {
+#          "errno": "108",
+#          "message": "invalid token",
+#        }
+#      })
+#  })
+#
+# You'll notice that there's some javascript written inline in this yaml file.
+# That does make it a little bit annoying to edit, but that's outweighed by
+# the advantage of have a single file that can be deployed with a single
+# command with no pre-processing palaver.
+#
+Parameters:
+  ProxyTarget:
+    Type: "String"
+    Default: "oauth.stage.mozaws.net"
+    Description: "The live OAuth server to which un-mocked requests should be proxied"
+  MockIssuer:
+    Type: "String"
+    Default: "mockmyid.s3-us-west-2.amazonaws.com"
+    Description: "The mock BrowserID issuer to advertise in config"
+  DomainName:
+    Type: "String"
+    Default: "mock-oauth-stage.dev.lcip.org"
+    Description: "The domain name at which to expose the API"
+  CertificateArn:
+    Type: "String"
+    Default: "arn:aws:acm:us-east-1:927034868273:certificate/675e0ac8-23af-4153-8295-acb28ccc9f0f"
+    Description: "The certificate to use with $DomainName"
+  HostedZoneName:
+    Type: "String"
+    Default: "lcip.org"
+    Description: "The hosted zone in which to create a DNS record"
+  Owner:
+    Type: "String"
+    Default: "rfkelly@mozilla.com"
+    Description: "Email address of owner to tag resources with"
+
+Resources:
+  Handler:
+    Type: "AWS::Lambda::Function"
+    Properties: 
+      Description: "Mock FxA OAuth verifier"
+      Handler: "index.handler"
+      Role:  !GetAtt HandlerRole.Arn
+      Tags:
+        - Key: "Owner"
+          Value: !Ref Owner
+      Runtime: "nodejs6.10"
+      Code: 
+        ZipFile: !Sub |-
+
+          const https = require('https');
+          const url = require('url');
+
+          function proxy(event, context, callback) {
+            const output = []
+            const req = https.request({
+              hostname: "${ProxyTarget}",
+              post: 443,
+              path: url.format({
+                pathname: event.path,
+                query: event.queryStringParameters
+              }),
+              method: event.httpMethod,
+            }, res => {
+              res.setEncoding('utf8');
+              res.on('data', d => {
+                output.push(d);
+              })
+              res.on('end', () => {
+                callback(null, {
+                  statusCode: res.statusCode,
+                  headers: res.headers,
+                  body: output.join('')
+                });
+              })
+            });            
+            req.on('error', e => {
+              callback(e);
+            })
+            if (event.body) {
+              req.write(event.body, 'utf8');
+            }
+            req.end();
+          }
+
+          const HANDLERS = {
+
+            'GET:/config': function(event, context, callback) {
+              return callback(null, {
+                statusCode: 200,
+                headers: {
+                  "content-type": "application/json"
+                },
+                body: '{ "browserid": { "issuer": "${MockIssuer}" } }'
+              });
+            },
+
+            'POST:/v1/verify': function(event, context, callback) {
+              try {
+                const token = JSON.parse(event.body).token;
+                const mockResponse = JSON.parse(token);
+                // Return the mocked response from the token.
+                return callback(null, {
+                  statusCode: mockResponse.status || 200,
+                  headers: {
+                    "content-type": "application/json"
+                  },
+                  body: JSON.stringify(mockResponse.body || {})
+                });
+              } catch (e) {
+                // If it's not a mock token, forward to real server.
+                return proxy(event, context, callback);
+              }
+            }
+          }
+
+          exports.handler = (event, context, callback) => {
+            const h = HANDLERS[event.httpMethod + ':' + event.path] || proxy;
+            return h(event, context, callback);
+          };
+
+  HandlerRole:
+    Type: "AWS::IAM::Role"
+    Properties: 
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+
+  HandlerPermission:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      Action: "lambda:invokeFunction"
+      FunctionName: !GetAtt Handler.Arn
+      Principal: "apigateway.amazonaws.com"
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${API}/*"
+
+  API:
+    Type: "AWS::ApiGateway::RestApi"
+    Properties:
+      Description: "Mock FxA OAuth API"
+      Name: !Sub "${AWS::StackName}-mock-fxa-oauth"
+      FailOnWarnings: true
+
+  APIResource:
+    Type: "AWS::ApiGateway::Resource"
+    Properties:
+      RestApiId: !Ref API
+      ParentId:  !GetAtt API.RootResourceId
+      PathPart: "{proxy+}"
+
+  APIMethod:
+    Type: "AWS::ApiGateway::Method"
+    DependsOn:
+      - HandlerPermission
+    Properties:
+      AuthorizationType: "NONE"
+      HttpMethod: "ANY"
+      ResourceId:  !Ref APIResource
+      RestApiId:  !Ref API
+      Integration:
+        Type: "AWS_PROXY"
+        IntegrationHttpMethod: "POST"
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Handler.Arn}/invocations"
+
+  APIDeployment:
+    Type: "AWS::ApiGateway::Deployment"
+    DependsOn:
+      - APIMethod
+    Properties:
+      RestApiId: !Ref API
+      StageName: "main"
+
+  APIDomainName:
+    Type: "AWS::ApiGateway::DomainName"
+    Properties:
+      DomainName: !Ref DomainName
+      CertificateArn: !Ref CertificateArn
+
+  APIDomainMapping:
+    Type: "AWS::ApiGateway::BasePathMapping"
+    Properties:
+      DomainName: !Ref APIDomainName
+      RestApiId:  !Ref API
+      Stage: "main"
+
+  APIDNSRecord:
+    Type : "AWS::Route53::RecordSet"
+    Properties :
+      HostedZoneName : !Sub "${HostedZoneName}."
+      Name : !Sub "${DomainName}."
+      Type : "A"
+      AliasTarget:
+        DNSName: !GetAtt APIDomainName.DistributionDomainName
+        HostedZoneId: "Z2FDTNDATAQYW2" # Published ZoneId for CloudFront

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ mozsvc==0.10
 Paste==2.0.3
 PasteDeploy==1.5.2
 PyBrowserID==0.12.0
+PyFxA==0.5.0
 PyMySQL==0.7.11
 pymysql-sa==1.0
 pyramid==1.8.4

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ requires = [
     'mozsvc',
     'Paste',
     'PyBrowserID',
+    'PyFxA',
     'PyMySQL',
     'pymysql_sa',
     'SQLAlchemy',

--- a/tokenserver/__init__.py
+++ b/tokenserver/__init__.py
@@ -37,9 +37,13 @@ def includeme(config):
     # initializes the assignment backend
     load_and_register("tokenserver", config)
 
-    # initialize the and browserid backend if it exists
+    # initialize the browserid backend if it exists
     if "browserid.backend" in settings:
         load_and_register("browserid", config)
+
+    # initialize the auth backend if it exists
+    if "oauth.backend" in settings:
+        load_and_register("oauth", config)
 
     # load apps and set them up back in the setting
     key = 'tokenserver.applications'

--- a/tokenserver/tests/assignment/test_sqlnode.py
+++ b/tokenserver/tests/assignment/test_sqlnode.py
@@ -31,14 +31,14 @@ class NodeAssignmentTests(object):
         self.backend.add_node('sync-1.0', 'https://phx12', 100)
 
     def test_node_allocation(self):
-        user = self.backend.get_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.get_user("sync-1.0", "test1@example.com")
         self.assertEquals(user, None)
 
-        user = self.backend.allocate_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.allocate_user("sync-1.0", "test1@example.com")
         wanted = 'https://phx12'
         self.assertEqual(user['node'], wanted)
 
-        user = self.backend.get_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.get_user("sync-1.0", "test1@example.com")
         self.assertEqual(user['node'], wanted)
 
     def test_allocation_to_least_loaded_node(self):
@@ -58,7 +58,7 @@ class NodeAssignmentTests(object):
             self.backend.allocate_user("sync-1.0", "test1@mozilla.com")
 
     def test_update_generation_number(self):
-        user = self.backend.allocate_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.allocate_user("sync-1.0", "test1@example.com")
         self.assertEqual(user['generation'], 0)
         self.assertEqual(user['client_state'], '')
         orig_uid = user['uid']
@@ -71,7 +71,7 @@ class NodeAssignmentTests(object):
         self.assertEqual(user['generation'], 42)
         self.assertEqual(user['client_state'], '')
 
-        user = self.backend.get_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.get_user("sync-1.0", "test1@example.com")
         self.assertEqual(user['uid'], orig_uid)
         self.assertEqual(user['node'], orig_node)
         self.assertEqual(user['generation'], 42)
@@ -84,14 +84,14 @@ class NodeAssignmentTests(object):
         self.assertEqual(user['generation'], 42)
         self.assertEqual(user['client_state'], '')
 
-        user = self.backend.get_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.get_user("sync-1.0", "test1@example.com")
         self.assertEqual(user['uid'], orig_uid)
         self.assertEqual(user['node'], orig_node)
         self.assertEqual(user['generation'], 42)
         self.assertEqual(user['client_state'], '')
 
     def test_update_client_state(self):
-        user = self.backend.allocate_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.allocate_user("sync-1.0", "test1@example.com")
         self.assertEqual(user['generation'], 0)
         self.assertEqual(user['client_state'], '')
         self.assertEqual(set(user['old_client_states']), set(()))
@@ -106,7 +106,7 @@ class NodeAssignmentTests(object):
         self.assertEqual(user['client_state'], 'aaa')
         self.assertEqual(set(user['old_client_states']), set(("",)))
 
-        user = self.backend.get_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.get_user("sync-1.0", "test1@example.com")
         self.assertTrue(user['uid'] not in seen_uids)
         self.assertEqual(user['node'], orig_node)
         self.assertEqual(user['generation'], 0)
@@ -124,7 +124,7 @@ class NodeAssignmentTests(object):
         self.assertEqual(user['client_state'], 'bbb')
         self.assertEqual(set(user['old_client_states']), set(("", "aaa")))
 
-        user = self.backend.get_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.get_user("sync-1.0", "test1@example.com")
         self.assertTrue(user['uid'] not in seen_uids)
         self.assertEqual(user['node'], orig_node)
         self.assertEqual(user['generation'], 12)
@@ -136,7 +136,7 @@ class NodeAssignmentTests(object):
         with self.assertRaises(BackendError):
             self.backend.update_user("sync-1.0", user, client_state="aaa")
 
-        user = self.backend.get_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.get_user("sync-1.0", "test1@example.com")
         self.assertEqual(user['uid'], orig_uid)
         self.assertEqual(user['node'], orig_node)
         self.assertEqual(user['generation'], 12)
@@ -391,7 +391,7 @@ class NodeAssignmentTests(object):
             self.backend.allocate_user(service, "test7@mozilla.com")
 
     def test_count_users(self):
-        user = self.backend.allocate_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.allocate_user("sync-1.0", "test1@example.com")
         self.assertEqual(self.backend.count_users(), 1)
         old_timestamp = get_timestamp()
         time.sleep(0.01)
@@ -404,12 +404,12 @@ class NodeAssignmentTests(object):
         # Looking back in time doesn't count newer users.
         self.assertEqual(self.backend.count_users(old_timestamp), 1)
         # Retiring a user decreases the count.
-        self.backend.retire_user("tarek@mozilla.com")
+        self.backend.retire_user("test1@example.com")
         self.assertEqual(self.backend.count_users(), 1)
 
     def test_first_seen_at(self):
         SERVICE = "sync-1.0"
-        EMAIL = "tarek@mozilla.com"
+        EMAIL = "test1@example.com"
         user0 = self.backend.allocate_user(SERVICE, EMAIL)
         user1 = self.backend.get_user(SERVICE, EMAIL)
         self.assertEqual(user1["uid"], user0["uid"])

--- a/tokenserver/tests/support.py
+++ b/tokenserver/tests/support.py
@@ -5,7 +5,7 @@ from browserid.tests.support import (make_assertion, get_keypair)
 
 
 # very dummy verifier
-class DummyVerifier(LocalVerifier):
+class DummyBrowserIdVerifier(LocalVerifier):
     def verify_certificate_chain(self, certs, *args, **kw):
         return certs[0]
 

--- a/tokenserver/tests/test_backend_sql.py
+++ b/tokenserver/tests/test_backend_sql.py
@@ -48,15 +48,15 @@ class TestSQLBackend(unittest.TestCase):
             self.backend._safe_execute('delete from users')
 
     def test_get_node(self):
-        user = self.backend.get_user("sync-1.0", "tarek@mozilla.com")
+        user = self.backend.get_user("sync-1.0", "test1@example.com")
         self.assertEquals(user, None)
 
-        user = self.backend.allocate_user("sync-1.0", "tarek@mozilla.com")
-        self.assertEqual(user['email'], "tarek@mozilla.com")
+        user = self.backend.allocate_user("sync-1.0", "test1@example.com")
+        self.assertEqual(user['email'], "test1@example.com")
         self.assertEqual(user['node'], "https://phx12")
 
-        user = self.backend.get_user("sync-1.0", "tarek@mozilla.com")
-        self.assertEqual(user['email'], "tarek@mozilla.com")
+        user = self.backend.get_user("sync-1.0", "test1@example.com")
+        self.assertEqual(user['email'], "test1@example.com")
         self.assertEqual(user['node'], "https://phx12")
 
     def test_get_patterns(self):

--- a/tokenserver/tests/test_local_browserid_verifier.py
+++ b/tokenserver/tests/test_local_browserid_verifier.py
@@ -6,7 +6,7 @@ import unittest
 
 from pyramid.config import Configurator
 
-from tokenserver.verifiers import LocalVerifier, IBrowserIdVerifier
+from tokenserver.verifiers import LocalBrowserIdVerifier, IBrowserIdVerifier
 from browserid.tests.support import (make_assertion,
                                      patched_supportdoc_fetching)
 import browserid.errors
@@ -16,13 +16,13 @@ class mockobj(object):
     pass
 
 
-class TestLocalVerifier(unittest.TestCase):
+class TestLocalBrowserIdVerifier(unittest.TestCase):
 
     DEFAULT_SETTINGS = {  # noqa; identation below is non-standard
         "tokenserver.backend":
             "tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend",
         "browserid.backend":
-            "tokenserver.verifiers.LocalVerifier",
+            "tokenserver.verifiers.LocalBrowserIdVerifier",
         "tokenserver.secrets.backend":
             "mozsvc.secrets.FixedSecrets",
         "tokenserver.secrets.secrets":
@@ -40,7 +40,7 @@ class TestLocalVerifier(unittest.TestCase):
     def test_verifier_config_loading_defaults(self):
         config = self._make_config()
         verifier = config.registry.getUtility(IBrowserIdVerifier)
-        self.assertTrue(isinstance(verifier, LocalVerifier))
+        self.assertTrue(isinstance(verifier, LocalBrowserIdVerifier))
         self.assertEquals(verifier.audiences, None)
         self.assertEquals(verifier.trusted_issuers, None)
         self.assertEquals(verifier.allowed_issuers, None)
@@ -55,7 +55,7 @@ class TestLocalVerifier(unittest.TestCase):
                 "example.com trustyidp.org\nmockmyid.com",
         })
         verifier = config.registry.getUtility(IBrowserIdVerifier)
-        self.assertTrue(isinstance(verifier, LocalVerifier))
+        self.assertTrue(isinstance(verifier, LocalBrowserIdVerifier))
         self.assertEquals(verifier.audiences, "https://testmytoken.com")
         self.assertEquals(verifier.trusted_issuers,
                           ["example.com", "trustyidp.org"])

--- a/tokenserver/tests/test_memorynode.ini
+++ b/tokenserver/tests/test_memorynode.ini
@@ -16,8 +16,11 @@ token_duration = 3600
 sync-1.1 = {node}/1.1/{uid}
 
 [browserid]
-backend = tokenserver.verifiers.RemoteVerifier
+backend = tokenserver.verifiers.RemoteBrowserIdVerifier
 audiences = http://tokenserver.services.mozilla.com
+
+[oauth]
+backend = tokenserver.verifiers.RemoteOAuthVerifier
 
 [fxa]
 metrics_uid_secret_key = 'super-sekrit'

--- a/tokenserver/tests/test_oauth_verifier.py
+++ b/tokenserver/tests/test_oauth_verifier.py
@@ -1,0 +1,188 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import socket
+import unittest
+import responses
+import contextlib
+
+from pyramid.config import Configurator
+
+from tokenserver.verifiers import (
+    IOAuthVerifier,
+    ConnectionError,
+    RemoteOAuthVerifier,
+)
+
+import fxa.errors
+
+
+MOCK_TOKEN = 'token'
+
+
+class TestRemoteOAuthVerifier(unittest.TestCase):
+
+    DEFAULT_SETTINGS = {  # noqa; identation below is non-standard
+        "tokenserver.backend":
+            "tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend",
+        "oauth.backend":
+            "tokenserver.verifiers.RemoteOAuthVerifier",
+        "tokenserver.secrets.backend":
+            "mozsvc.secrets.FixedSecrets",
+        "tokenserver.secrets.secrets":
+            "steve-let-the-dogs-out",
+    }
+
+    def _make_config(self, settings={}):
+        all_settings = self.DEFAULT_SETTINGS.copy()
+        all_settings.update(settings)
+        config = Configurator(settings=all_settings)
+        config.include("tokenserver")
+        config.commit()
+        return config
+
+    @contextlib.contextmanager
+    def _mock_verifier(self, verifier, response=None, exc=None):
+        def replacement_verify_token_method(*args, **kwds):
+            if exc is not None:
+                raise exc
+            if response is not None:
+                return response
+            raise RuntimeError("incomplete mock")
+        orig_verify_token_method = verifier._client.verify_token
+        verifier._client.verify_token = replacement_verify_token_method
+        try:
+            yield None
+        finally:
+            verifier._client.verify_token = orig_verify_token_method
+
+    def test_verifier_config_loading_defaults(self):
+        config = self._make_config()
+        verifier = config.registry.getUtility(IOAuthVerifier)
+        self.assertTrue(isinstance(verifier, RemoteOAuthVerifier))
+        self.assertEquals(verifier.server_url,
+                          "https://oauth.accounts.firefox.com/v1")
+        self.assertEquals(verifier.default_issuer,
+                          "api.accounts.firefox.com")
+        self.assertEquals(verifier.scope,
+                          "https://identity.mozilla.com/apps/oldsync")
+        self.assertEquals(verifier.timeout, 30)
+
+    def test_verifier_config_loading_values(self):
+        config = self._make_config({  # noqa; indentation below is non-standard
+            "oauth.server_url":
+                "https://oauth-test1.dev.lcip.org/",
+            "oauth.default_issuer":
+                "myissuer.com",
+            "oauth.scope":
+                "some.custom.scope",
+            "oauth.timeout": 500
+        })
+        verifier = config.registry.getUtility(IOAuthVerifier)
+        self.assertTrue(isinstance(verifier, RemoteOAuthVerifier))
+        self.assertEquals(verifier.server_url,
+                          "https://oauth-test1.dev.lcip.org/v1")
+        self.assertEquals(verifier.default_issuer, "myissuer.com")
+        self.assertEquals(verifier.scope, "some.custom.scope")
+        self.assertEquals(verifier.timeout, 500)
+
+    @responses.activate
+    def test_verifier_config_dynamic_issuer_discovery(self):
+        responses.add(
+            responses.GET,
+            "https://oauth-server.my-self-hosted-setup.com/config",
+            json={
+                "browserid": {
+                    "issuer": "authy.my-self-hosted-setup.com",
+                },
+            }
+        )
+        config = self._make_config({  # noqa; indentation below is non-standard
+            "oauth.server_url":
+                "https://oauth-server.my-self-hosted-setup.com/",
+        })
+        verifier = config.registry.getUtility(IOAuthVerifier)
+        self.assertEqual(len(responses.calls), 1)
+        self.assertTrue(isinstance(verifier, RemoteOAuthVerifier))
+        self.assertEquals(verifier.server_url,
+                          "https://oauth-server.my-self-hosted-setup.com/v1")
+        self.assertEquals(verifier.default_issuer,
+                          "authy.my-self-hosted-setup.com")
+
+    @responses.activate
+    def test_verifier_config_handles_missing_default_issuer(self):
+        responses.add(
+            responses.GET,
+            "https://oauth-server.my-self-hosted-setup.com/config",
+            json={
+                "browserid": {
+                    "oh no": "the issuer is not configured here"
+                },
+            }
+        )
+        config = self._make_config({  # noqa; indentation below is non-standard
+            "oauth.server_url":
+                "https://oauth-server.my-self-hosted-setup.com/",
+        })
+        verifier = config.registry.getUtility(IOAuthVerifier)
+        self.assertEqual(len(responses.calls), 1)
+        self.assertTrue(isinstance(verifier, RemoteOAuthVerifier))
+        self.assertEquals(verifier.server_url,
+                          "https://oauth-server.my-self-hosted-setup.com/v1")
+        self.assertEquals(verifier.default_issuer, None)
+
+    def test_verifier_config_rejects_empty_scope(self):
+        with self.assertRaises(ValueError):
+            self._make_config({
+                "oauth.scope": ""
+            })
+
+    def test_verifier_failure_cases(self):
+        config = self._make_config()
+        verifier = config.registry.getUtility(IOAuthVerifier)
+        with self._mock_verifier(verifier, exc=socket.error):
+            with self.assertRaises(ConnectionError):
+                verifier.verify(MOCK_TOKEN)
+        err = fxa.errors.ScopeMismatchError(verifier.scope, 'wrong.scope')
+        with self._mock_verifier(verifier, exc=err):
+            with self.assertRaises(fxa.errors.ScopeMismatchError):
+                verifier.verify(MOCK_TOKEN)
+
+    def test_verifier_constructs_email_from_uid_and_reported_issuer(self):
+        config = self._make_config({  # noqa; indentation below is non-standard
+            "oauth.default_issuer":
+                "my.default.issuer.com",
+        })
+        verifier = config.registry.getUtility(IOAuthVerifier)
+        mock_response = {"user": "UID", "issuer": "my.custom.issuer.com"}
+        with self._mock_verifier(verifier, response=mock_response):
+            self.assertEquals(verifier.verify(MOCK_TOKEN)["email"],
+                              "UID@my.custom.issuer.com")
+
+    def test_verifier_constructs_email_from_uid_and_default_issuer(self):
+        config = self._make_config({  # noqa; indentation below is non-standard
+            "oauth.default_issuer":
+                "my.custom.issuer.com",
+        })
+        verifier = config.registry.getUtility(IOAuthVerifier)
+        with self._mock_verifier(verifier, response={"user": "UID"}):
+            self.assertEquals(verifier.verify(MOCK_TOKEN)["email"],
+                              "UID@my.custom.issuer.com")
+
+    @responses.activate
+    def test_verifier_fails_if_issuer_cannot_be_determined(self):
+        responses.add(
+            responses.GET,
+            "https://oauth-server.my-self-hosted-setup.com/config",
+            json={},
+        )
+        config = self._make_config({  # noqa; indentation below is non-standard
+            "oauth.server_url":
+                "https://oauth-server.my-self-hosted-setup.com/",
+        })
+        verifier = config.registry.getUtility(IOAuthVerifier)
+        self.assertEqual(len(responses.calls), 1)
+        with self._mock_verifier(verifier, response={"user": "UID"}):
+            with self.assertRaises(fxa.errors.TrustError):
+                verifier.verify(MOCK_TOKEN)

--- a/tokenserver/tests/test_remote_browserid_verifier.py
+++ b/tokenserver/tests/test_remote_browserid_verifier.py
@@ -8,7 +8,7 @@ import unittest
 
 from pyramid.config import Configurator
 
-from tokenserver.verifiers import RemoteVerifier, IBrowserIdVerifier
+from tokenserver.verifiers import RemoteBrowserIdVerifier, IBrowserIdVerifier
 from browserid.tests.support import make_assertion
 import browserid.errors
 
@@ -17,19 +17,19 @@ class mockobj(object):
     pass
 
 
-class TestRemoteVerifier(unittest.TestCase):
+class TestRemoteBrowserIdVerifier(unittest.TestCase):
 
     DEFAULT_SETTINGS = {  # noqa; identation below is non-standard
         "tokenserver.backend":
             "tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend",
         "browserid.backend":
-            "tokenserver.verifiers.RemoteVerifier",
+            "tokenserver.verifiers.RemoteBrowserIdVerifier",
         "tokenserver.secrets.backend":
             "mozsvc.secrets.FixedSecrets",
         "tokenserver.secrets.secrets":
             "steve-let-the-dogs-out",
         "browserid.backend":
-            "tokenserver.verifiers.RemoteVerifier",
+            "tokenserver.verifiers.RemoteBrowserIdVerifier",
     }
 
     def _make_config(self, settings={}):
@@ -60,7 +60,7 @@ class TestRemoteVerifier(unittest.TestCase):
     def test_verifier_config_loading_defaults(self):
         config = self._make_config()
         verifier = config.registry.getUtility(IBrowserIdVerifier)
-        self.assertTrue(isinstance(verifier, RemoteVerifier))
+        self.assertTrue(isinstance(verifier, RemoteBrowserIdVerifier))
         self.assertEquals(verifier.verifier_url,
                           "https://verifier.accounts.firefox.com/v2")
         self.assertEquals(verifier.audiences, None)
@@ -79,7 +79,7 @@ class TestRemoteVerifier(unittest.TestCase):
                 "example.com trustyidp.org\nmockmyid.com",
         })
         verifier = config.registry.getUtility(IBrowserIdVerifier)
-        self.assertTrue(isinstance(verifier, RemoteVerifier))
+        self.assertTrue(isinstance(verifier, RemoteBrowserIdVerifier))
         self.assertEquals(verifier.verifier_url,
                           "https://trustyverifier.notascam.com/endpoint/path")
         self.assertEquals(verifier.audiences, "https://testmytoken.com")

--- a/tokenserver/tests/test_service.py
+++ b/tokenserver/tests/test_service.py
@@ -84,7 +84,7 @@ class TestService(unittest.TestCase):
                 verifier.__dict__["verify"] = orig_verify_method
 
     def _getassertion(self, **kw):
-        kw.setdefault('email', 'tarek@mozilla.com')
+        kw.setdefault('email', 'test1@example.com')
         kw.setdefault('audience', 'http://tokenserver.services.mozilla.com')
         return make_assertion(**kw).encode('ascii')
 

--- a/tokenserver/tests/test_service.py
+++ b/tokenserver/tests/test_service.py
@@ -15,8 +15,12 @@ from mozsvc.config import load_into_settings
 from mozsvc.plugin import load_and_register
 
 from tokenserver.assignment import INodeAssignment
-from tokenserver.verifiers import get_verifier
+from tokenserver.verifiers import (
+    get_browserid_verifier,
+    get_oauth_verifier
+)
 
+import fxa.errors
 import browserid.errors
 from browserid.tests.support import make_assertion
 from browserid.utils import get_assertion_info
@@ -42,13 +46,16 @@ class TestService(unittest.TestCase):
         wsgiapp = self.config.make_wsgi_app()
         self.app = TestApp(wsgiapp)
         # Mock out the verifier to return successfully by default.
-        self.mock_verifier_context = self.mock_verifier()
-        self.mock_verifier_context.__enter__()
+        self.mock_browserid_verifier_context = self.mock_browserid_verifier()
+        self.mock_browserid_verifier_context.__enter__()
+        self.mock_oauth_verifier_context = self.mock_oauth_verifier()
+        self.mock_oauth_verifier_context.__enter__()
         self.logs = LogCapture()
 
     def tearDown(self):
         self.logs.uninstall()
-        self.mock_verifier_context.__exit__(None, None, None)
+        self.mock_oauth_verifier_context.__exit__(None, None, None)
+        self.mock_browserid_verifier_context.__exit__(None, None, None)
 
     def assertMetricWasLogged(self, key):
         """Check that a metric was logged during the request."""
@@ -62,7 +69,7 @@ class TestService(unittest.TestCase):
         del self.logs.records[:]
 
     @contextlib.contextmanager
-    def mock_verifier(self, response=None, exc=None):
+    def mock_browserid_verifier(self, response=None, exc=None):
         def mock_verify_method(assertion):
             if exc is not None:
                 raise exc
@@ -72,7 +79,29 @@ class TestService(unittest.TestCase):
                 "status": "okay",
                 "email": get_assertion_info(assertion)["principal"]["email"],
             }
-        verifier = get_verifier(self.config.registry)
+        verifier = get_browserid_verifier(self.config.registry)
+        orig_verify_method = verifier.__dict__.get("verify", None)
+        verifier.__dict__["verify"] = mock_verify_method
+        try:
+            yield None
+        finally:
+            if orig_verify_method is None:
+                del verifier.__dict__["verify"]
+            else:
+                verifier.__dict__["verify"] = orig_verify_method
+
+    @contextlib.contextmanager
+    def mock_oauth_verifier(self, response=None, exc=None):
+        def mock_verify_method(token):
+            if exc is not None:
+                raise exc
+            if response is not None:
+                return response
+            return {
+                "email": token.decode("hex"),
+                "idpClaims": {},
+            }
+        verifier = get_oauth_verifier(self.config.registry)
         orig_verify_method = verifier.__dict__.get("verify", None)
         verifier.__dict__["verify"] = mock_verify_method
         try:
@@ -87,6 +116,9 @@ class TestService(unittest.TestCase):
         kw.setdefault('email', 'test1@example.com')
         kw.setdefault('audience', 'http://tokenserver.services.mozilla.com')
         return make_assertion(**kw).encode('ascii')
+
+    def _gettoken(self, email='test1@example.com'):
+        return email.encode('hex')
 
     def test_unknown_app(self):
         headers = {'Authorization': 'BrowserID %s' % self._getassertion()}
@@ -116,6 +148,15 @@ class TestService(unittest.TestCase):
             'auth': 'http://localhost',
             'services': {
                 'sync': ['1.1', '1.5'],
+            },
+            'browserid': {
+                'allowed_issuers': None,
+                'trusted_issuers': None,
+            },
+            'oauth': {
+                'default_issuer': 'api.accounts.firefox.com',
+                'scope': 'https://identity.mozilla.com/apps/oldsync',
+                'server_url': 'https://oauth.accounts.firefox.com/v1',
             }
         })
 
@@ -136,25 +177,28 @@ class TestService(unittest.TestCase):
         self.assertEqual(res.json, {})
 
     def test_unauthorized_error_status(self):
-        assertion = self._getassertion()
         # Totally busted auth -> generic error.
         headers = {'Authorization': 'Unsupported-Auth-Scheme IHACKYOU'}
         res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
         self.assertEqual(res.json['status'], 'error')
-        # Bad signature -> "invalid-credentials"
+
+        # BrowserID verifier errors
+        assertion = self._getassertion()
         headers = {'Authorization': 'BrowserID %s' % assertion}
-        with self.mock_verifier(exc=browserid.errors.InvalidSignatureError):
+        # Bad signature -> "invalid-credentials"
+        errs = browserid.errors
+        with self.mock_browserid_verifier(exc=errs.InvalidSignatureError):
             res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
         self.assertEqual(res.json['status'], 'invalid-credentials')
         # Bad audience -> "invalid-credentials"
-        with self.mock_verifier(exc=browserid.errors.AudienceMismatchError):
+        with self.mock_browserid_verifier(exc=errs.AudienceMismatchError):
             res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
         self.assertEqual(res.json['status'], 'invalid-credentials')
         self.assertMetricWasLogged('token.assertion.verify_failure')
         self.assertMetricWasLogged('token.assertion.audience_mismatch_error')
         self.clearLogs()
         # Expired timestamp -> "invalid-timestamp"
-        with self.mock_verifier(exc=browserid.errors.ExpiredSignatureError):
+        with self.mock_browserid_verifier(exc=errs.ExpiredSignatureError):
             res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
         self.assertEqual(res.json['status'], 'invalid-timestamp')
         self.assertTrue('X-Timestamp' in res.headers)
@@ -162,7 +206,7 @@ class TestService(unittest.TestCase):
         self.assertMetricWasLogged('token.assertion.expired_signature_error')
         self.clearLogs()
         # Connection error -> 503
-        with self.mock_verifier(exc=browserid.errors.ConnectionError):
+        with self.mock_browserid_verifier(exc=errs.ConnectionError):
             res = self.app.get('/1.0/sync/1.1', headers=headers, status=503)
         self.assertMetricWasLogged('token.assertion.verify_failure')
         self.assertMetricWasLogged('token.assertion.connection_error')
@@ -175,7 +219,33 @@ class TestService(unittest.TestCase):
             assert False, "failed to log a traceback for ConnectionError"
         self.clearLogs()
         # Some other wacky error -> not captured
-        with self.mock_verifier(exc=ValueError):
+        with self.mock_browserid_verifier(exc=ValueError):
+            with self.assertRaises(ValueError):
+                res = self.app.get('/1.0/sync/1.1', headers=headers)
+
+        # OAuth verifier errors
+        token = self._gettoken()
+        headers = {'Authorization': 'Bearer %s' % token}
+        # Bad token -> "invalid-credentials"
+        err = fxa.errors.TrustError({"code": 400, "errno": 123})
+        with self.mock_oauth_verifier(exc=err):
+            res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
+        self.assertEqual(res.json['status'], 'invalid-credentials')
+        # Connection error -> 503
+        with self.mock_oauth_verifier(exc=errs.ConnectionError):
+            res = self.app.get('/1.0/sync/1.1', headers=headers, status=503)
+        self.assertMetricWasLogged('token.oauth.verify_failure')
+        self.assertMetricWasLogged('token.oauth.connection_error')
+        # It should also log a full traceback of the error.
+        for r in self.logs.records:
+            if r.msg == "Unexpected verification error":
+                assert r.exc_info is not None
+                break
+        else:
+            assert False, "failed to log a traceback for ConnectionError"
+        self.clearLogs()
+        # Some other wacky error -> not captured
+        with self.mock_oauth_verifier(exc=ValueError):
             with self.assertRaises(ValueError):
                 res = self.app.get('/1.0/sync/1.1', headers=headers)
 
@@ -187,15 +257,15 @@ class TestService(unittest.TestCase):
             "email": "test@mozilla.com",
             "idpClaims": {}
         }
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             self.app.get("/1.0/sync/1.1", headers=headers, status=200)
         # Assertion should not be rejected if fxa-tokenVerified is True
         mock_response['idpClaims']['fxa-tokenVerified'] = True
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             self.app.get("/1.0/sync/1.1", headers=headers, status=200)
         # Assertion should be rejected if fxa-tokenVerified is False
         mock_response['idpClaims']['fxa-tokenVerified'] = False
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get("/1.0/sync/1.1", headers=headers, status=401)
         self.assertEqual(res.json['status'], 'invalid-credentials')
 
@@ -203,61 +273,61 @@ class TestService(unittest.TestCase):
         headers = {"Authorization": "BrowserID %s" % self._getassertion()}
         # Start with no generation number.
         mock_response = {"status": "okay", "email": "test@mozilla.com"}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res1 = self.app.get("/1.0/sync/1.1", headers=headers)
         # Now send an explicit generation number.
         # The node assignment should not change.
         mock_response["idpClaims"] = {"fxa-generation": 12}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res2 = self.app.get("/1.0/sync/1.1", headers=headers)
         self.assertEqual(res1.json["uid"], res2.json["uid"])
         self.assertEqual(res1.json["api_endpoint"], res2.json["api_endpoint"])
         # Previous generation numbers get an invalid-generation response.
         del mock_response["idpClaims"]
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get("/1.0/sync/1.1", headers=headers, status=401)
         self.assertEqual(res.json["status"], "invalid-generation")
         mock_response["idpClaims"] = {"some-nonsense": "lolwut"}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get("/1.0/sync/1.1", headers=headers, status=401)
         self.assertEqual(res.json["status"], "invalid-generation")
         mock_response["idpClaims"] = {"fxa-generation": 10}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get("/1.0/sync/1.1", headers=headers, status=401)
         self.assertEqual(res.json["status"], "invalid-generation")
         # Equal generation numbers are accepted.
         mock_response["idpClaims"] = {"fxa-generation": 12}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res2 = self.app.get("/1.0/sync/1.1", headers=headers)
         self.assertEqual(res1.json["uid"], res2.json["uid"])
         self.assertEqual(res1.json["api_endpoint"], res2.json["api_endpoint"])
         # Later generation numbers are accepted.
         # Again, the node assignment should not change.
         mock_response["idpClaims"] = {"fxa-generation": 13}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res2 = self.app.get("/1.0/sync/1.1", headers=headers)
         self.assertEqual(res1.json["uid"], res2.json["uid"])
         self.assertEqual(res1.json["api_endpoint"], res2.json["api_endpoint"])
         # And that should lock out the previous generation number
         mock_response["idpClaims"] = {"fxa-generation": 12}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get("/1.0/sync/1.1", headers=headers, status=401)
         self.assertEqual(res.json["status"], "invalid-generation")
         # Various nonsense generation numbers should give errors.
         mock_response["idpClaims"] = {"fxa-generation": "whatswrongwithyour"}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get("/1.0/sync/1.1", headers=headers, status=401)
         self.assertEqual(res.json["status"], "invalid-generation")
         mock_response["idpClaims"] = {"fxa-generation": None}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get("/1.0/sync/1.1", headers=headers, status=401)
         self.assertEqual(res.json["status"], "invalid-generation")
         mock_response["idpClaims"] = {"fxa-generation": "42"}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get("/1.0/sync/1.1", headers=headers, status=401)
         self.assertEqual(res.json["status"], "invalid-generation")
         mock_response["idpClaims"] = {"fxa-generation": ["I", "HACK", "YOU"]}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get("/1.0/sync/1.1", headers=headers, status=401)
         self.assertEqual(res.json["status"], "invalid-generation")
 
@@ -269,16 +339,16 @@ class TestService(unittest.TestCase):
         }
         # Start with no client-state header.
         headers = {'Authorization': 'BrowserID %s' % self._getassertion()}
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers)
         uid0 = res.json['uid']
         # No change == same uid.
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers)
         self.assertEqual(res.json['uid'], uid0)
         # Changing client-state header requires changing generation number.
         headers['X-Client-State'] = 'aaaa'
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
         self.assertEqual(res.json['status'], 'invalid-client-state')
         desc = res.json['errors'][0]['description']
@@ -286,40 +356,40 @@ class TestService(unittest.TestCase):
         # Change the client-state header, get a new uid.
         headers['X-Client-State'] = 'aaaa'
         mock_response["idpClaims"]["fxa-generation"] += 1
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers)
         uid1 = res.json['uid']
         self.assertNotEqual(uid1, uid0)
         # No change == same uid.
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers)
         self.assertEqual(res.json['uid'], uid1)
         # Send a client-state header, get a new uid.
         headers['X-Client-State'] = 'bbbb'
         mock_response["idpClaims"]["fxa-generation"] += 1
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers)
         uid2 = res.json['uid']
         self.assertNotEqual(uid2, uid0)
         self.assertNotEqual(uid2, uid1)
         # No change == same uid.
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers)
         self.assertEqual(res.json['uid'], uid2)
         # Use a previous client-state, get an auth error.
         headers['X-Client-State'] = 'aaaa'
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
         self.assertEqual(res.json['status'], 'invalid-client-state')
         desc = res.json['errors'][0]['description']
         self.assertTrue(desc.endswith('stale value'))
         del headers['X-Client-State']
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
         self.assertEqual(res.json['status'], 'invalid-client-state')
         headers['X-Client-State'] = 'aaaa'
         mock_response["idpClaims"]["fxa-generation"] += 1
-        with self.mock_verifier(response=mock_response):
+        with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
         self.assertEqual(res.json['status'], 'invalid-client-state')
 
@@ -346,6 +416,57 @@ class TestService(unittest.TestCase):
         headers['X-Client-State'] = 'aaa'
         res = self.app.get('/1.0/sync/1.1', headers=headers)
         self.assertEqual(res.json['uid'], uid0)
+
+    def test_credentials_from_oauth_and_browserid(self):
+        # Send initial credentials via oauth.
+        headers_oauth = {
+            "Authorization": "Bearer %s" % self._gettoken(),
+            "X-KeyID": "12-YWFh",
+        }
+        res1 = self.app.get("/1.0/sync/1.1", headers=headers_oauth)
+        # Send the same credentials via BrowserID
+        headers_browserid = {
+            "Authorization": "BrowserID %s" % self._getassertion(),
+            "X-Client-State": "616161",
+        }
+        mock_response = {
+            "status": "okay",
+            "email": "test1@example.com",
+            "idpClaims": {"fxa-generation": 12},
+        }
+        with self.mock_browserid_verifier(response=mock_response):
+            res2 = self.app.get("/1.0/sync/1.1", headers=headers_browserid)
+        # They should get the same node assignment.
+        self.assertEqual(res1.json["uid"], res2.json["uid"])
+        self.assertEqual(res1.json["api_endpoint"], res2.json["api_endpoint"])
+        # Earlier generation number via BrowserID -> invalid-generation
+        mock_response["idpClaims"]['fxa-generation'] = 11
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get("/1.0/sync/1.1", headers=headers_browserid,
+                               status=401)
+        self.assertEqual(res.json["status"], "invalid-generation")
+        # Earlier generation number via OAuth -> invalid-generation
+        headers_oauth['X-KeyID'] = '11-YWFh'
+        res = self.app.get("/1.0/sync/1.1", headers=headers_oauth, status=401)
+        self.assertEqual(res.json["status"], "invalid-generation")
+        # Change client-state via BrowserID.
+        headers_browserid['X-Client-State'] = '626262'
+        mock_response["idpClaims"]['fxa-generation'] = 42
+        with self.mock_browserid_verifier(response=mock_response):
+            res1 = self.app.get("/1.0/sync/1.1", headers=headers_browserid)
+        # Old OAuth credentials are rejected.
+        headers_oauth['X-KeyID'] = '12-YWFh'
+        res = self.app.get("/1.0/sync/1.1", headers=headers_oauth, status=401)
+        self.assertEqual(res.json["status"], "invalid-client-state")
+        headers_oauth['X-KeyID'] = '12-YmJi'
+        res = self.app.get("/1.0/sync/1.1", headers=headers_oauth, status=401)
+        self.assertEqual(res.json["status"], "invalid-generation")
+        # Updated OAuth credentials are accepted.
+        headers_oauth['X-KeyID'] = '42-YmJi'
+        res2 = self.app.get("/1.0/sync/1.1", headers=headers_oauth)
+        # They should again get the same node assignment.
+        self.assertEqual(res1.json["uid"], res2.json["uid"])
+        self.assertEqual(res1.json["api_endpoint"], res2.json["api_endpoint"])
 
     def test_client_specified_duration(self):
         headers = {'Authorization': 'BrowserID %s' % self._getassertion()}

--- a/tokenserver/verifiers.py
+++ b/tokenserver/verifiers.py
@@ -6,19 +6,34 @@ from zope.interface import implements, Interface
 
 import socket
 import requests
+import urlparse
 
-from browserid.verifiers.local import LocalVerifier as LocalVerifier_
+import browserid.verifiers.local
 from browserid.errors import (InvalidSignatureError, ExpiredSignatureError,
                               ConnectionError, AudienceMismatchError,
                               InvalidIssuerError)
 from browserid.supportdoc import SupportDocumentManager
 
+import fxa.oauth
+import fxa.errors
+import fxa.constants
 
-def get_verifier(registry=None):
-    """returns the registered verifier, building it if necessary."""
+
+DEFAULT_OAUTH_SCOPE = 'https://identity.mozilla.com/apps/oldsync'
+
+
+def get_browserid_verifier(registry=None):
+    """returns the registered browserid verifier."""
     if registry is None:
         registry = get_current_registry()
     return registry.getUtility(IBrowserIdVerifier)
+
+
+def get_oauth_verifier(registry=None):
+    """returns the registered oauth verifier."""
+    if registry is None:
+        registry = get_current_registry()
+    return registry.getUtility(IOAuthVerifier)
 
 
 # This is to simplify the registering of the implementations using pyramid
@@ -27,8 +42,12 @@ class IBrowserIdVerifier(Interface):
     pass
 
 
+class IOAuthVerifier(Interface):
+    pass
+
+
 # The default verifier from browserid
-class LocalVerifier(LocalVerifier_):
+class LocalBrowserIdVerifier(browserid.verifiers.local.LocalVerifier):
     implements(IBrowserIdVerifier)
 
     def __init__(self, trusted_issuers=None, allowed_issuers=None, **kwargs):
@@ -57,7 +76,7 @@ class LocalVerifier(LocalVerifier_):
         kwargs["supportdocs"] = SupportDocumentManager(verify=verify)
         # Disable warning about evolving data formats, it's out of date.
         kwargs.setdefault("warning", False)
-        super(LocalVerifier, self).__init__(**kwargs)
+        super(LocalBrowserIdVerifier, self).__init__(**kwargs)
 
     def _emit_warning():
         """Emit a scary warning to discourage unverified SSL access."""
@@ -70,7 +89,7 @@ class LocalVerifier(LocalVerifier_):
         warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
     def verify(self, assertion, audience=None):
-        data = super(LocalVerifier, self).verify(assertion, audience)
+        data = super(LocalBrowserIdVerifier, self).verify(assertion, audience)
         if self.allowed_issuers is not None:
             issuer = data.get('issuer')
             if issuer not in self.allowed_issuers:
@@ -83,7 +102,7 @@ class LocalVerifier(LocalVerifier_):
 # of the assertion, and hasn't been updated for the new BrowserID formats.
 # Rather than blocking on that work, we use a simple work-alike that doesn't
 # do any local inspection of the assertion.
-class RemoteVerifier(object):
+class RemoteBrowserIdVerifier(object):
     implements(IBrowserIdVerifier)
 
     def __init__(self, audiences=None, trusted_issuers=None,
@@ -144,3 +163,76 @@ class RemoteVerifier(object):
             if issuer not in self.allowed_issuers:
                 raise InvalidIssuerError("Issuer not allowed: %s" % (issuer,))
         return data
+
+
+class RemoteOAuthVerifier(object):
+    """A Verifier for FxA OAuth tokens that posts to a verifiaction service.
+
+    This verifier uses the remote FxA OAuth verification service to accept
+    OAuth tokens, and translates the returned data into something that
+    approximates the information provided by BrowserID.
+
+    In order to meet tokenserver's expectation that users are identified
+    with an email address, it combines the FxA uid with the hostname of
+    the corresponding FxA BrowserID issuer.  For non-standard FxA hosting
+    setups this might require it to dynamically discover the BrowserID
+    issuer by querying the OAuth verifier's configuration.
+    """
+    implements(IOAuthVerifier)
+
+    def __init__(self, server_url=None, default_issuer=None, timeout=30,
+                 scope=DEFAULT_OAUTH_SCOPE):
+        if not scope:
+            raise ValueError('Expected a non-empty "scope" argument')
+        self._client = fxa.oauth.Client(server_url=server_url)
+        self._client.timeout = timeout
+        if default_issuer is None:
+            # This server_url will have been normalized to end in /v1.
+            server_url = self._client.server_url
+            # Try to find the auth-server that matches the given oauth-server.
+            # For well-known servers this avoids discovering it dynamically.
+            for urls in fxa.constants.ENVIRONMENT_URLS.itervalues():
+                if urls['oauth'] == server_url:
+                    auth_url = urls['authentication']
+                    default_issuer = urlparse.urlparse(auth_url).netloc
+                    break
+            else:
+                # For non-standard hosting setups, look it up dynamically.
+                r = requests.get(server_url[:-3] + '/config')
+                r.raise_for_status()
+                try:
+                    default_issuer = r.json()['browserid']['issuer']
+                except KeyError:
+                    pass
+        self.default_issuer = default_issuer
+        self.scope = scope
+
+    @property
+    def server_url(self):
+        return self._client.server_url
+
+    @property
+    def timeout(self):
+        return self._client.timeout
+
+    def verify(self, token):
+        try:
+            userinfo = self._client.verify_token(token, self.scope)
+        except (socket.error, requests.RequestException), e:
+            msg = 'Verification request to %s failed; reason: %s'
+            msg %= (self.server_url, str(e))
+            raise ConnectionError(msg)
+        issuer = userinfo.get('issuer', self.default_issuer)
+        if not issuer or not isinstance(issuer, basestring):
+            msg = 'Could not determine issuer from verifier response'
+            raise fxa.errors.TrustError(msg)
+        return {
+          'email': userinfo['user'] + '@' + issuer,
+          'idpClaims': {},
+        }
+
+
+# For backwards-compatibility with self-hosting setups
+# which might be referencing these via their old names.
+LocalVerifier = LocalBrowserIdVerifier
+RemoteVerifier = RemoteBrowserIdVerifier


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1455219

The main idea here is to fork the "verifier" logic into two different mechanisms - the current one that accepts BrowserID assertions, and a new one that accepts OAuth tokens.  The actual verification of tokens is handled by [PyFxA](https://github.com/mozilla/PyFxA), this just plumbs it in to tokenserver and smooshes the result into a form that matches the output from BrowserID.