### PR TITLE
Include raw FxA user-id and key-id in Hawk token.

### DIFF
--- a/tokenserver/assignment/sqlnode/sql.py
+++ b/tokenserver/assignment/sqlnode/sql.py
@@ -100,7 +100,7 @@ where
 
 _GET_OLD_USER_RECORDS_FOR_SERVICE = sqltext("""\
 select
-    uid, nodes.node, created_at, replaced_at
+    uid, email, client_state, nodes.node, created_at, replaced_at
 from
     users left outer join nodes on users.nodeid = nodes.id
 where


### PR DESCRIPTION
This is a sketch of how we might implement #121, sending the raw FxA uid and key-id as part of the hawk token id.   It will need some tests, and it may be an opportunity to refactor out some common helper functions for this stuff.

Connects to #121

/cc @bbangert @philbooth @pjenvey