### PR TITLE
Remove the unused umemcache dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ SQLAlchemy==1.1.10
 testfixtures==5.1.1
 tokenlib==0.3.1
 translationstring==1.3
-umemcache==1.6.3
 urllib3==1.21.1
 venusian==1.1.0
 WebOb==1.7.2

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ requires = [
     'SQLAlchemy',
     'testfixtures',
     'tokenlib',
-    'umemcache',
 ]
 
 tests_require = [


### PR DESCRIPTION
There has been a dependency to `umemcache` for many years.
Unfortunately the package is unmaintained since a few years and only supports Python 2. This is one blocker in the move to support Python 3.

Most interestingly there isn't any reference to `umemcache` in the code.
I did some digging on this and it looks like with commit `31eaa57797283b5cd4da5a93450638be9059d1dc` is responsible for removing the component that actually used `umemcache` (_powerhose_), but `umemcache` wasn't touched during this.
The commit mentions [bugzilla #1004246](https://bugzilla.mozilla.org/show_bug.cgi?id=1004246).