### PR TITLE
fix apparent typo in docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ case "$1" in
             --timeout ${TOKENSERVER_TIMEOUT-600} \
             --workers ${WEB_CONCURRENCY-1}\
             --graceful-timeout ${TOKENSERVER_GRACEFUL_TIMEOUT-660}\
-            --max-requests ${TOKENSERER__MAX_REQUESTS-5000}\
+            --max-requests ${TOKENSERVER_MAX_REQUESTS-5000}\
             --log-config "$_SETTINGS_FILE"
         ;;
 


### PR DESCRIPTION
Small typo, looks like. SERER not SERVER.

r? - @autrilla 