### PR TITLE
provide `python` target on entrypoint for workers

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,6 +23,10 @@ case "$1" in
             --log-config "$_SETTINGS_FILE"
         ;;
 
+    python)
+        exec "$@"
+        ;;
+
     test_all)
         $0 test_flake8
         $0 test_nose


### PR DESCRIPTION
The worker tasks start with a python command line like "python -m tokenserver.scripts.process_account_events -v ./settings.ini ts-account-change-stage". So `docker-entrypoint.sh` needs a case to handle and exec that command.

(Something about this doesn't reallly feel right, though).