### PR TITLE
Reduce annoying log messages in stage loadtests

### DIFF
--- a/tokenserver/assignment/sqlnode/sql.py
+++ b/tokenserver/assignment/sqlnode/sql.py
@@ -100,7 +100,8 @@ where
 
 _GET_OLD_USER_RECORDS_FOR_SERVICE = sqltext("""\
 select
-    uid, email, client_state, nodes.node, created_at, replaced_at
+    uid, email, client_state, nodes.node, nodes.downed,
+    created_at, replaced_at
 from
     users left outer join nodes on users.nodeid = nodes.id
 where


### PR DESCRIPTION
This fixes 2 out of 4 causes of annoying log messages in stage tokenserver loadtests that were reported in [Bug 1533257](https://bugzilla.mozilla.org/show_bug.cgi?id=1533257):

* When the oauth server returns `errno=108`, that just means that the OAuth token has expired. We don't need to log a full traceback in this case.
* When purging old records, don't try to delete from the node if we know it's down.

The other 2 causes will have to be fixed elsewhere.