### PR TITLE
Allow OAuth clients to not report a generation number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The `generation` column is used to detect when the user's FxA credentials have b
 and to lock out clients that have not been updated with the latest credentials.
 Tokenserver tracks the highest value of `generation` that it has ever seen for a user,
 and rejects BrowserID assertions in which the `generation` number is less than that high-water mark.
+Note that OAuth clients do not provide a `generation` number, because OAuth tokens get
+revoked immediately when the user's credentials are changed.
 
 The `client_state` column is used to detect when the user's encryption key changes.
 When it sees a new value for `client_state`, Tokenserver will replace the user's node assignment


### PR DESCRIPTION
For OAuth clients, the timestamp component of the `X-KeyID` header is supposed to represent the time at which the keys were last changed.  We have instead been using is the "generation number", which is the timestamp at which the user's *password* was last changed.  Once FxA starts [separately tracking the key-rotation timestamp](https://github.com/mozilla/fxa/pull/2570), these two numbers will sometimes diverge and we risk locking out OAuth clients if we continue to use it as the generation number.

This change exempts OAuth clients from the generation-number checking logic, by having them always report a generation number of `0`.