### PR TITLE
Track key-rotation timestamp if provided by the IdP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,9 @@ build-requirements:
 	$(TEMPDIR)/bin/pip freeze | grep -v -- '^-e' > requirements.txt
 
 tests: install-dev
-	$(VENV)/bin/nosetests tokenserver/tests
+	# By default nose will skip tests in executable files, but that's annoying
+	# when working in WSL with a checkout mounted from the native filesystem.
+	$(VENV)/bin/nosetests --exe tokenserver/tests
 
 flake8: install-dev
 	$(VENV)/bin/flake8 tokenserver

--- a/tokenserver/assignment/__init__.py
+++ b/tokenserver/assignment/__init__.py
@@ -20,7 +20,7 @@ class INodeAssignment(Interface):
         """
 
     def allocate_user(self, service, email, generation=0, client_state='',
-                      node=None):
+                      keys_changed_at=0, node=None):
         """Create a new user record for the given service and email.
 
         The newly-created user record is returned in the format described
@@ -28,7 +28,7 @@ class INodeAssignment(Interface):
         """
 
     def update_user(self, service, user, generation=None, client_state=None,
-                    node=None):
+                    keys_changed_at=None, node=None):
         """Update the user record for the given service.
 
         This method can be used to update the last-seen generation number,

--- a/tokenserver/assignment/memorynode.py
+++ b/tokenserver/assignment/memorynode.py
@@ -37,7 +37,7 @@ class MemoryNodeAssignmentBackend(object):
         return self._users.get((service, email), None)
 
     def allocate_user(self, service, email, generation=0, client_state='',
-                      node=None):
+                      keys_changed_at=0, node=None):
         if (service, email) in self._users:
             raise BackendError('user already exists: ' + email)
         if node is not None and node != self.service_entry:
@@ -47,6 +47,7 @@ class MemoryNodeAssignmentBackend(object):
             'uid': self._next_uid,
             'node': self.service_entry,
             'generation': generation,
+            'keys_changed_at': keys_changed_at,
             'client_state': client_state,
             'old_client_states': {},
             'first_seen_at': get_timestamp()
@@ -56,13 +57,15 @@ class MemoryNodeAssignmentBackend(object):
         return user
 
     def update_user(self, service, user, generation=None, client_state=None,
-                    node=None):
+                    keys_changed_at=None, node=None):
         if (service, user['email']) not in self._users:
             raise BackendError('unknown user: ' + user['email'])
         if node is not None and node != self.service_entry:
             raise ValueError("unknown node: %s" % (node,))
         if generation is not None:
             user['generation'] = generation
+        if keys_changed_at is not None:
+            user['keys_changed_at'] = keys_changed_at
         if client_state is not None:
             user['old_client_states'][user['client_state']] = True
             user['client_state'] = client_state

--- a/tokenserver/assignment/sqlnode/migrations/versions/75e8ca84b0bc_add_keys_changed_at_column.py
+++ b/tokenserver/assignment/sqlnode/migrations/versions/75e8ca84b0bc_add_keys_changed_at_column.py
@@ -1,0 +1,29 @@
+# flake8: noqa
+"""add_keys_changed_at_column
+
+Revision ID: 75e8ca84b0bc
+Revises: 2b968b28bcdc
+Create Date: 2019-10-14 12:09:18.257878
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '75e8ca84b0bc'
+down_revision = '2b968b28bcdc'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # Create the column, making it nullable so that it can be
+    # safely inserted in the present of existing data.
+    op.add_column(
+        'users',
+        sa.Column('keys_changed_at', sa.BigInteger(), nullable=True)
+    )
+    pass
+
+
+def downgrade():
+    op.drop_column('users', 'keys_changed_at')

--- a/tokenserver/assignment/sqlnode/schemas.py
+++ b/tokenserver/assignment/sqlnode/schemas.py
@@ -46,6 +46,7 @@ class _UsersBase(object):
     email = Column(String(255), nullable=False)
     nodeid = Column(BigInteger(), nullable=True)
     generation = Column(BigInteger(), nullable=False)
+    keys_changed_at = Column(BigInteger(), nullable=True)
     client_state = Column(String(32), nullable=False)
     created_at = Column(BigInteger(), nullable=False)
     replaced_at = Column(BigInteger(), nullable=True)

--- a/tokenserver/assignment/sqlnode/sql.py
+++ b/tokenserver/assignment/sqlnode/sql.py
@@ -269,7 +269,7 @@ class SQLNodeAssignment(object):
                 'uid': cur_row.uid,
                 'node': cur_row.node,
                 'generation': cur_row.generation,
-                'keys_changed_at': cur_row.keys_changed_at,
+                'keys_changed_at': cur_row.keys_changed_at or 0,
                 'client_state': cur_row.client_state,
                 'old_client_states': {},
                 'first_seen_at': cur_row.created_at

--- a/tokenserver/scripts/purge_old_records.py
+++ b/tokenserver/scripts/purge_old_records.py
@@ -28,6 +28,7 @@ import hawkauthlib
 
 import tokenserver.scripts
 from tokenserver.assignment import INodeAssignment
+from tokenserver.util import format_key_id
 
 
 logger = logging.getLogger("tokenserver.scripts.purge_old_records")
@@ -97,7 +98,10 @@ def delete_service_data(config, service, user, timeout=60):
         "uid": user.uid,
         "node": user.node,
         "fxa_uid": user.email.split("@", 1)[0],
-        "fxa_kid": user.client_state
+        "fxa_kid": format_key_id(
+            user.keys_changed_at or user.generation,
+            user.client_state.decode('hex')
+        ),
     }, secret=node_secrets[-1])
     secret = tokenlib.get_derived_secret(token, secret=node_secrets[-1])
     endpoint = pattern.format(uid=user.uid, service=service, node=user.node)

--- a/tokenserver/tests/test_service.py
+++ b/tokenserver/tests/test_service.py
@@ -361,7 +361,7 @@ class TestService(unittest.TestCase):
         mock_response = {
             "status": "okay",
             "email": "test@mozilla.com",
-            "idpClaims": {"fxa-generation": 1234},
+            "idpClaims": {"fxa-generation": 1234, "fxa-keysChangedAt": 1234},
         }
         # Start with no client-state header.
         headers = {'Authorization': 'BrowserID %s' % self._getassertion()}
@@ -372,16 +372,24 @@ class TestService(unittest.TestCase):
         with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers)
         self.assertEqual(res.json['uid'], uid0)
-        # Changing client-state header requires changing generation number.
+        # Changing client-state header requires changing generation.
         headers['X-Client-State'] = 'aaaa'
         with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
         self.assertEqual(res.json['status'], 'invalid-client-state')
         desc = res.json['errors'][0]['description']
         self.assertTrue(desc.endswith('new value with no generation change'))
-        # Change the client-state header, get a new uid.
-        headers['X-Client-State'] = 'aaaa'
+        # Changing client-state header requires changing keys_changed_at.
         mock_response["idpClaims"]["fxa-generation"] += 1
+        headers['X-Client-State'] = 'aaaa'
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
+        self.assertEqual(res.json['status'], 'invalid-client-state')
+        desc = res.json['errors'][0]['description']
+        self.assertTrue(desc.endswith('with no keys_changed_at change'))
+        # Change the client-state header, get a new uid.
+        mock_response["idpClaims"]["fxa-keysChangedAt"] += 1
+        headers['X-Client-State'] = 'aaaa'
         with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers)
         uid1 = res.json['uid']
@@ -393,6 +401,7 @@ class TestService(unittest.TestCase):
         # Send a client-state header, get a new uid.
         headers['X-Client-State'] = 'bbbb'
         mock_response["idpClaims"]["fxa-generation"] += 1
+        mock_response["idpClaims"]["fxa-keysChangedAt"] += 1
         with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers)
         uid2 = res.json['uid']
@@ -415,15 +424,128 @@ class TestService(unittest.TestCase):
         self.assertEqual(res.json['status'], 'invalid-client-state')
         headers['X-Client-State'] = 'aaaa'
         mock_response["idpClaims"]["fxa-generation"] += 1
+        mock_response["idpClaims"]["fxa-keysChangedAt"] += 1
         with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
         self.assertEqual(res.json['status'], 'invalid-client-state')
+
+    def test_fxa_kid_change(self):
+        # Starting off not reporting keys_changed_at.
+        # We don't expect to encounter this in production, but it might
+        # happen to self-hosters who update tokenserver without updating
+        # their FxA stack.
+        headers = {
+            "Authorization": "BrowserID %s" % self._getassertion(),
+            "X-Client-State": "616161",
+        }
+        mock_response = {
+            "status": "okay",
+            "email": "test@mozilla.com",
+            "idpClaims": {"fxa-generation": 1234},
+        }
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers)
+        token = self.unsafelyParseToken(res.json["id"])
+        self.assertEqual(token["fxa_kid"], "0000000001234-YWFh")
+        # Now pretend we updated FxA and it started sending keys_changed_at.
+        mock_response["idpClaims"]["fxa-generation"] = 2345
+        mock_response["idpClaims"]["fxa-keysChangedAt"] = 2345
+        headers["X-Client-State"] = "626262"
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers)
+        token = self.unsafelyParseToken(res.json["id"])
+        self.assertEqual(token["fxa_kid"], "0000000002345-YmJi")
+        # If we roll back the FxA stack so it stops reporting keys_changed_at,
+        # users will get locked out because we can't produce `fxa_kid`.
+        del mock_response["idpClaims"]["fxa-keysChangedAt"]
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
+        self.assertEqual(res.json["status"], "invalid-keysChangedAt")
+        # We will likewise reject values below the high-water mark.
+        mock_response["idpClaims"]["fxa-keysChangedAt"] = 2340
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
+        self.assertEqual(res.json["status"], "invalid-keysChangedAt")
+        # But accept the correct value, even if generation number changes.
+        mock_response["idpClaims"]["fxa-generation"] = 3456
+        mock_response["idpClaims"]["fxa-keysChangedAt"] = 2345
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers)
+        token = self.unsafelyParseToken(res.json["id"])
+        self.assertEqual(token["fxa_kid"], "0000000002345-YmJi")
+        # We'll error if it changes without a change in generation.
+        mock_response["idpClaims"]["fxa-keysChangedAt"] = 4567
+        headers["X-Client-State"] = "636363"
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
+        self.assertEqual(res.json["status"], "invalid-keysChangedAt")
+        # But accept further updates if both values change in unison.
+        mock_response["idpClaims"]["fxa-generation"] = 4567
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers)
+        token = self.unsafelyParseToken(res.json["id"])
+        self.assertEqual(token["fxa_kid"], "0000000004567-Y2Nj")
+
+    def test_fxa_kid_change_with_oauth(self):
+        # Starting off not reporting keys_changed_at.
+        # This uses BrowserID since OAuth always reports keys_changed_at.
+        headers_browserid = {
+            "Authorization": "BrowserID %s" % self._getassertion(),
+            "X-Client-State": "616161",
+        }
+        mock_response = {
+            "status": "okay",
+            "email": "test@mozilla.com",
+            "idpClaims": {"fxa-generation": 1234},
+        }
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers_browserid)
+        token = self.unsafelyParseToken(res.json["id"])
+        self.assertEqual(token["fxa_kid"], "0000000001234-YWFh")
+        # Now an OAuth client shows up, setting keys_changed_at.
+        # (The value matches generation number above, beause in this scenario
+        # FxA hasn't been updated to track and report keysChangedAt yet).
+        headers_oauth = {
+            "Authorization": "Bearer %s" % self._gettoken("test@mozilla.com"),
+            "X-KeyID": "1234-YWFh",
+        }
+        res = self.app.get('/1.0/sync/1.1', headers=headers_oauth)
+        token = self.unsafelyParseToken(res.json["id"])
+        self.assertEqual(token["fxa_kid"], "0000000001234-YWFh")
+        # At this point, BrowserID clients are locked out until FxA is updated,
+        # because we're now expecting to see keys_changed_at for that user.
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers_browserid,
+                               status=401)
+        self.assertEqual(res.json["status"], "invalid-keysChangedAt")
+        # We will likewise reject values below the high-water mark.
+        mock_response["idpClaims"]["fxa-keysChangedAt"] = 1230
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers_browserid,
+                               status=401)
+        self.assertEqual(res.json["status"], "invalid-keysChangedAt")
+        headers_oauth["X-KeyID"] = "1230-YWFh"
+        res = self.app.get('/1.0/sync/1.1', headers=headers_oauth, status=401)
+        self.assertEqual(res.json["status"], "invalid-keysChangedAt")
+        # We accept new values via OAuth.
+        headers_oauth["X-KeyID"] = "2345-YmJi"
+        res = self.app.get('/1.0/sync/1.1', headers=headers_oauth)
+        token = self.unsafelyParseToken(res.json["id"])
+        self.assertEqual(token["fxa_kid"], "0000000002345-YmJi")
+        # And via BrowserID, as long as generation number increases as well.
+        headers_browserid["X-Client-State"] = "636363"
+        mock_response["idpClaims"]["fxa-generation"] = 3456
+        mock_response["idpClaims"]["fxa-keysChangedAt"] = 3456
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers_browserid)
+        token = self.unsafelyParseToken(res.json["id"])
+        self.assertEqual(token["fxa_kid"], "0000000003456-Y2Nj")
 
     def test_client_state_cannot_revert_to_empty(self):
         # Start with a client-state header.
         headers = {
             'Authorization': 'BrowserID %s' % self._getassertion(),
-            'X-Client-State': 'aaa',
+            'X-Client-State': 'aaaa',
         }
         res = self.app.get('/1.0/sync/1.1', headers=headers)
         uid0 = res.json['uid']
@@ -439,7 +561,7 @@ class TestService(unittest.TestCase):
         desc = res.json['errors'][0]['description']
         self.assertTrue(desc.endswith('empty string'))
         # And the uid will be unchanged.
-        headers['X-Client-State'] = 'aaa'
+        headers['X-Client-State'] = 'aaaa'
         res = self.app.get('/1.0/sync/1.1', headers=headers)
         self.assertEqual(res.json['uid'], uid0)
 
@@ -447,7 +569,7 @@ class TestService(unittest.TestCase):
         # Send initial credentials via oauth.
         headers_oauth = {
             "Authorization": "Bearer %s" % self._gettoken(),
-            "X-KeyID": "12-YWFh",
+            "X-KeyID": "7-YWFh",
         }
         res1 = self.app.get("/1.0/sync/1.1", headers=headers_oauth)
         # Send the same credentials via BrowserID
@@ -458,7 +580,7 @@ class TestService(unittest.TestCase):
         mock_response = {
             "status": "okay",
             "email": "test1@example.com",
-            "idpClaims": {"fxa-generation": 12},
+            "idpClaims": {"fxa-generation": 12, "fxa-keysChangedAt": 7},
         }
         with self.mock_browserid_verifier(response=mock_response):
             res2 = self.app.get("/1.0/sync/1.1", headers=headers_browserid)
@@ -472,16 +594,28 @@ class TestService(unittest.TestCase):
                                status=401)
         self.assertEqual(res1.json["api_endpoint"], res2.json["api_endpoint"])
         self.assertEqual(res.json["status"], "invalid-generation")
-        # Earlier generation number via OAuth is accepted.
-        headers_oauth['X-KeyID'] = '11-YWFh'
-        res1 = self.app.get("/1.0/sync/1.1", headers=headers_oauth)
-        self.assertEqual(res1.json["api_endpoint"], res2.json["api_endpoint"])
+        # Earlier keys_changed_at via BrowserID is not accepted.
+        mock_response["idpClaims"]['fxa-generation'] = 12
+        mock_response["idpClaims"]['fxa-keysChangedAt'] = 6
+        with self.mock_browserid_verifier(response=mock_response):
+            res1 = self.app.get("/1.0/sync/1.1", headers=headers_browserid,
+                                status=401)
+        self.assertEqual(res1.json['status'], 'invalid-keysChangedAt')
+        # Earlier keys_changed_at via OAuth is not accepted.
+        headers_oauth['X-KeyID'] = '6-YWFh'
+        res1 = self.app.get("/1.0/sync/1.1", headers=headers_oauth, status=401)
+        self.assertEqual(res1.json['status'], 'invalid-keysChangedAt')
         # Change client-state via BrowserID.
         headers_browserid['X-Client-State'] = '626262'
         mock_response["idpClaims"]['fxa-generation'] = 42
+        mock_response["idpClaims"]['fxa-keysChangedAt'] = 42
         with self.mock_browserid_verifier(response=mock_response):
             res1 = self.app.get("/1.0/sync/1.1", headers=headers_browserid)
-        # Updated OAuth credentials are accepted.
+        # Previous OAuth creds are rejected due to keys_changed_at update.
+        headers_oauth['X-KeyID'] = '7-YmJi'
+        res2 = self.app.get("/1.0/sync/1.1", headers=headers_oauth, status=401)
+        self.assertEqual(res2.json['status'], 'invalid-keysChangedAt')
+        # Updated OAuth creds are accepted.
         headers_oauth['X-KeyID'] = '42-YmJi'
         res2 = self.app.get("/1.0/sync/1.1", headers=headers_oauth)
         # They should again get the same node assignment.
@@ -547,14 +681,14 @@ class TestService(unittest.TestCase):
         mock_response = {
             "status": "okay",
             "email": "testuser@example.com",
-            "idpClaims": {"fxa-generation": 12},
+            "idpClaims": {"fxa-generation": 13, 'fxa-keysChangedAt': 12},
         }
         with self.mock_browserid_verifier(response=mock_response):
             res = self.app.get("/1.0/sync/1.1", headers=headers_browserid)
         token = self.unsafelyParseToken(res.json["id"])
         self.assertEqual(token["uid"], res.json["uid"])
         self.assertEqual(token["fxa_uid"], "testuser")
-        self.assertEqual(token["fxa_kid"], "616161")
+        self.assertEqual(token["fxa_kid"], "0000000000012-YWFh")
         self.assertNotEqual(token["hashed_fxa_uid"], token["fxa_uid"])
         self.assertEqual(token["hashed_fxa_uid"], res.json["hashed_fxa_uid"])
         self.assertIn("hashed_device_id", token)
@@ -569,7 +703,7 @@ class TestService(unittest.TestCase):
         token = self.unsafelyParseToken(res.json["id"])
         self.assertEqual(token["uid"], res.json["uid"])
         self.assertEqual(token["fxa_uid"], "testuser")
-        self.assertEqual(token["fxa_kid"], "616161")
+        self.assertEqual(token["fxa_kid"], "0000000000012-YWFh")
         self.assertNotEqual(token["hashed_fxa_uid"], token["fxa_uid"])
         self.assertEqual(token["hashed_fxa_uid"], res.json["hashed_fxa_uid"])
         self.assertIn("hashed_device_id", token)

--- a/tokenserver/util.py
+++ b/tokenserver/util.py
@@ -11,6 +11,8 @@ import time
 from pyramid.response import Response
 from pyramid import httpexceptions as exc
 
+from browserid.utils import encode_bytes as encode_bytes_b64
+from browserid.utils import decode_bytes as decode_bytes_b64
 from cornice.errors import Errors
 
 
@@ -102,3 +104,19 @@ def find_config_file(*paths):
 def get_timestamp():
     """Get current timestamp in milliseconds."""
     return int(time.time() * 1000)
+
+
+def parse_key_id(kid):
+    """Parse an FxA key ID into its constituent timestamp and key hash."""
+    keys_changed_at, key_hash = kid.split("-", 1)
+    keys_changed_at = int(keys_changed_at)
+    key_hash = decode_bytes_b64(key_hash)
+    return (keys_changed_at, key_hash)
+
+
+def format_key_id(keys_changed_at, key_hash):
+    """Format an FxA key ID from a timestamp and key hash."""
+    return "{:013d}-{}".format(
+        keys_changed_at,
+        encode_bytes_b64(key_hash),
+    )

--- a/tokenserver/views.py
+++ b/tokenserver/views.py
@@ -382,10 +382,16 @@ def return_token(request):
     if generation > user['generation']:
         updates['generation'] = generation
     if keys_changed_at > user['keys_changed_at']:
-        # If there's a generation number available, then
-        # a change in keys should correspond to a change in generation number.
+        # If there's a generation number available, then a change
+        # in keys should correspond to a change in generation number.
         if generation > 0 and 'generation' not in updates:
-            raise _unauthorized('invalid-keysChangedAt')
+            # TODO: We can't accurately detect this case until all servers are
+            # reliably writing keys_changed_at to the database, so it will need
+            # to wait and be deployed separately. In the meantime we check that
+            # it's at least using the most-recently-seen generation number.
+            # Remove this `if` once keys_changed_at is fully deployed.
+            if generation != user['generation']:
+                raise _unauthorized('invalid-keysChangedAt')
         updates['keys_changed_at'] = keys_changed_at
     if client_state != user['client_state']:
         # Don't revert from some-client-state to no-client-state.

--- a/tokenserver/views.py
+++ b/tokenserver/views.py
@@ -11,7 +11,6 @@ from cornice import Service
 from mozsvc.metrics import metrics_timer
 from pyramid import httpexceptions
 
-
 import tokenlib
 
 from tokenserver.verifiers import (
@@ -21,7 +20,12 @@ from tokenserver.verifiers import (
     get_oauth_verifier
 )
 from tokenserver.assignment import INodeAssignment
-from tokenserver.util import json_error, fxa_metrics_hash
+from tokenserver.util import (
+    json_error,
+    fxa_metrics_hash,
+    parse_key_id,
+    format_key_id
+)
 
 import fxa.errors
 import browserid.errors
@@ -91,10 +95,23 @@ def _invalid_client_state(reason, **kw):
 # validators
 
 def valid_authorization(request, **kwargs):
-    """Validate that the Authorization on the request is correct.
+    """Validate that the Authorization on the request is correct and valid.
 
-    If not, add errors in the response so that the client can know what
-    happened.
+    If authorization is valid, this validator populates user information into
+    `request.validated` as follows:
+
+      * `authorization`: a dict of information about the user:
+        * `email`: user id in the form "{userid}@{issuer}"
+        * `idpClaims`: a dict of optional extra claims from the IdP:
+          * `fxa-generation`: timestamp at which user credentials last changed
+          * `fxa-keysChangedAt`: timestamp at which user keys last changed
+      * `fxa_uid`: the userid component of `authorization.email`
+      * `client_state`: hash of the user's key material, as a hex string
+      * `hashed_fxa_uid`: hmaced `fxa_uid`, to use for metrics
+      * `hashed_device_id`: hmaced device identifier, to use for metrics
+
+    If authorization is not valid, this validator adds errors in the response
+    so that the client can know what happened.
     """
     authz = request.headers.get('Authorization')
     if authz is None:
@@ -227,10 +244,9 @@ def _validate_oauth_token(request, token):
     if kid:
         try:
             # The kid combines a timestamp and a hash of the key material.
-            # Unfortunately the timestamp is not guaranteed to be the same
-            # as the `generation` number from BrowserID assertions.
-            _, client_state = kid.split("-", 1)
-            client_state = browserid.utils.decode_bytes(client_state)
+            keys_changed_at, client_state = parse_key_id(kid)
+            idpClaims = request.validated['authorization']['idpClaims']
+            idpClaims['fxa-keysChangedAt'] = keys_changed_at
             client_state = client_state.encode('hex')
             if not 1 <= len(client_state) <= 32:
                 raise json_error(400, location='header', name='X-Client-State',
@@ -310,9 +326,11 @@ VALIDATORS = (
 def return_token(request):
     """This service does the following process:
 
-    - validates the BrowserID assertion provided on the Authorization header
+    - validates the BrowserID or OAuth credentials provided in the
+      Authorization header
     - allocates when necessary a node to the user for the required service
-    - checks generation numbers and x-client-state header
+    - checks generation number, key-rotation timestamp and x-client-state
+      header for consistency
     - returns a JSON mapping containing the following values:
 
         - **id** -- a signed authorization token, containing the
@@ -321,19 +339,26 @@ def return_token(request):
         - **uid** -- the user id for this servic
         - **api_endpoint** -- the root URL for the user for the service.
     """
-    # at this stage, we are sure that the assertion, application and version
+    # at this stage, we are sure that the credentials, application and version
     # number were valid, so let's build the authentication token and return it.
     backend = request.registry.getUtility(INodeAssignment)
     settings = request.registry.settings
     email = request.validated['authorization']['email']
+
+    # The `generation` and `keys_changed_at` fields are both optional.
     try:
         idp_claims = request.validated['authorization']['idpClaims']
     except KeyError:
         generation = 0
+        keys_changed_at = 0
     else:
         generation = idp_claims.get('fxa-generation', 0)
         if not isinstance(generation, (int, long)):
             raise _unauthorized("invalid-generation")
+        keys_changed_at = idp_claims.get('fxa-keysChangedAt', 0)
+        if not isinstance(keys_changed_at, (int, long)):
+            raise _unauthorized("invalid-credentials",
+                                description="invalid keysChangedAt")
 
     application = request.validated['application']
     version = request.validated['version']
@@ -349,12 +374,19 @@ def return_token(request):
             raise _unauthorized('new-users-disabled')
         with metrics_timer('tokenserver.backend.allocate_user', request):
             user = backend.allocate_user(service, email, generation,
-                                         client_state)
+                                         client_state,
+                                         keys_changed_at=keys_changed_at)
 
     # Update if this client is ahead of previously-seen clients.
     updates = {}
     if generation > user['generation']:
         updates['generation'] = generation
+    if keys_changed_at > user['keys_changed_at']:
+        # If there's a generation number available, then
+        # a change in keys should correspond to a change in generation number.
+        if generation > 0 and 'generation' not in updates:
+            raise _unauthorized('invalid-keysChangedAt')
+        updates['keys_changed_at'] = keys_changed_at
     if client_state != user['client_state']:
         # Don't revert from some-client-state to no-client-state.
         if not client_state:
@@ -364,21 +396,31 @@ def return_token(request):
             raise _invalid_client_state('stale value')
         # If we have a generation number, then
         # don't update client-state without a change in generation number.
-        if generation > 0:
-            if user['generation'] > 0 and 'generation' not in updates:
-                raise _invalid_client_state(
-                    'new value with no generation change')
+        if generation > 0 and 'generation' not in updates:
+            raise _invalid_client_state(
+                'new value with no generation change')
+        # If the IdP has been sending keys_changed_at timestamps, then
+        # don't update client-state without a change in keys_changed_at.
+        if user['keys_changed_at'] > 0 and 'keys_changed_at' not in updates:
+            raise _invalid_client_state(
+                'new value with no keys_changed_at change')
         updates['client_state'] = client_state
     if updates:
         with metrics_timer('tokenserver.backend.update_user', request):
             backend.update_user(service, user, **updates)
 
-    # Error out if this client is behind the generation number of some
-    # previously-seen client.
-    # This is done after the updates because some other, even more up-to-date
-    # client may have raced with a concurrent update.
+    # Error out if this client provided a generation number, but it is behind
+    # the generation number of some previously-seen client.
     if generation > 0 and user['generation'] > generation:
         raise _unauthorized("invalid-generation")
+
+    # Error out if we previously saw a keys_changed_at for this user, but they
+    # haven't provided one or it's earlier than previously seen. This means
+    # that once the IdP starts sending keys_changed_at, we'll error out if it
+    # stops (because we can't generate a proper `fxa_kid` in this case).
+    if user['keys_changed_at'] > 0:
+        if user['keys_changed_at'] > keys_changed_at:
+            raise _unauthorized("invalid-keysChangedAt")
 
     secrets = settings['tokenserver.secrets']
     node_secrets = secrets.get(user['node'])
@@ -404,7 +446,11 @@ def return_token(request):
         'node': user['node'],
         'expires': int(time.time()) + token_duration,
         'fxa_uid': request.validated['fxa_uid'],
-        'fxa_kid': request.validated['client-state'],
+        'fxa_kid': format_key_id(
+            # Follow FxA behaviour of using generation as a fallback.
+            user['keys_changed_at'] or user['generation'],
+            client_state.decode('hex')
+        ),
         'hashed_fxa_uid': request.validated['hashed_fxa_uid'],
         'hashed_device_id': request.validated['hashed_device_id']
     }


### PR DESCRIPTION
This is a quick sketch of the changes that might be required for https://github.com/mozilla-services/tokenserver/issues/124.  It's missing the underlying database migration and any tests, but I wanted to put it up as a kind of explainer for what might be required, and for early feedback.