### PR TITLE
Prep v1.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ tests_require = [
 
 
 setup(name='tokenserver',
-      version='1.4.2',
+      version='1.4.3',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,


### PR DESCRIPTION
A new release to get the [oauth generation-number change](https://github.com/mozilla/fxa/pull/2570) out, which is step (1) of (3) in our effort to [track key-rotation timestamps](https://github.com/mozilla-services/tokenserver/issues/124).