### PR TITLE
Report `node_type` for inclusion in client-side metrics.

### DIFF
--- a/tokenserver/tests/test_memorynode.ini
+++ b/tokenserver/tests/test_memorynode.ini
@@ -11,6 +11,8 @@ applications = sync-1.1, sync-1.5
 secrets_file = tokenserver/tests/secrets tokenserver/tests/secrets2
 node = https://example.com
 token_duration = 3600
+node_type_patterns =
+  example:*example*
 
 [endpoints]
 sync-1.1 = {node}/1.1/{uid}

--- a/tokenserver/tests/test_node_type_classifier.py
+++ b/tokenserver/tests/test_node_type_classifier.py
@@ -1,0 +1,82 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+
+from pyramid.config import Configurator
+
+
+class TestNodeTypeClassifier(unittest.TestCase):
+
+    DEFAULT_SETTINGS = {  # noqa; identation below is non-standard
+        "tokenserver.backend":
+            "tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend",
+        "oauth.backend":
+            "tokenserver.verifiers.RemoteOAuthVerifier",
+        "tokenserver.secrets.backend":
+            "mozsvc.secrets.FixedSecrets",
+        "tokenserver.secrets.secrets":
+            "steve-let-the-dogs-out",
+    }
+
+    def _make_classifier(self, settings={}):
+        all_settings = self.DEFAULT_SETTINGS.copy()
+        all_settings.update(settings)
+        config = Configurator(settings=all_settings)
+        config.include("tokenserver")
+        config.commit()
+        return config.registry.settings['tokenserver.node_type_classifier']
+
+    def test_no_patterns(self):
+        classifier = self._make_classifier()
+        self.assertEquals(classifier(''), None)
+        self.assertEquals(classifier('https://example.com'), None)
+
+    def test_error_if_not_a_list(self):
+        with self.assertRaises(ValueError):
+            self._make_classifier({
+                'tokenserver.node_type_patterns': 'foo:*.bar.com',
+
+            })
+
+    def test_error_if_pattern_has_no_label(self):
+        with self.assertRaises(ValueError):
+            self._make_classifier({
+                'tokenserver.node_type_patterns': [
+                    ':*.bar.com',
+                ],
+            })
+
+    def test_error_if_duplicate_pattern_label(self):
+        with self.assertRaises(ValueError):
+            self._make_classifier({
+                'tokenserver.node_type_patterns': [
+                    'foo:*.foo.com',
+                    'foo:*.bar.com',
+                ],
+            })
+
+    def test_pattern_matching(self):
+        classifier = self._make_classifier({
+            'tokenserver.node_type_patterns': [
+                'foo:*.foo.com',
+                'bar:*.bar.com',
+            ],
+        })
+        self.assertEquals(classifier(''), None)
+        self.assertEquals(classifier('https://example.com'), None)
+        self.assertEquals(classifier('https://example.foo.com'), 'foo')
+        self.assertEquals(classifier('https://example.bar.com'), 'bar')
+
+    def test_precedence_order(self):
+        classifier = self._make_classifier({
+            'tokenserver.node_type_patterns': [
+                'foo1:*foo.foo.com',
+                'foo2:*.foo.com',
+            ],
+        })
+        self.assertEquals(classifier(''), None)
+        self.assertEquals(classifier('https://foo.com'), None)
+        self.assertEquals(classifier('https://example.foo.com'), 'foo2')
+        self.assertEquals(classifier('https://foo.foo.com'), 'foo1')

--- a/tokenserver/tests/test_service.py
+++ b/tokenserver/tests/test_service.py
@@ -771,6 +771,12 @@ class TestService(unittest.TestCase):
         res = self.app.get('/1.0/sync/1.1', headers=headers, status=200)
         self.assertTrue('hashed_fxa_uid' in res.json)
 
+    def test_node_type_is_returned_in_response(self):
+        assertion = self._getassertion(email="newuser2@test.com")
+        headers = {'Authorization': 'BrowserID %s' % assertion}
+        res = self.app.get('/1.0/sync/1.1', headers=headers, status=200)
+        self.assertEqual(res.json['node_type'], 'example')
+
 
 class TestServiceWithSQLBackend(TestService):
 

--- a/tokenserver/tests/test_sql.ini
+++ b/tokenserver/tests/test_sql.ini
@@ -13,6 +13,8 @@ token_duration = 3600
 secrets.backend = mozsvc.secrets.DerivedSecrets
 secrets.master_secrets = "abcdef"
                          "123456"
+node_type_patterns =
+  example:*example.com
 
 [endpoints]
 sync-1.1 = {node}/1.1/{uid}


### PR DESCRIPTION
Ref [Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1582317](https://bugzilla.mozilla.org/show_bug.cgi?id=1582317); obviously extremely WIP!

The idea here is to have tokenserver return a short string value for clients to include in the sync ping, which we can use for segmented analysis of sync client metrics. By putting the server in charge of this value we gain a lot of operational flexibility without having to update client code - for example, if the initial rollout of a `"new`" node type is a bit of a bust, we might like to be able to introduce a `"new2"` node type without disrupting the users already allocated to the previous one.

There are many wayswe could have tokenserver determine the appropriate value to send - we could make it a column in the `nodes` table, we could do a simple string match or regex, or maybe something else. I don't have strong opinions on that front.