### PR TITLE
Prep v1.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ tests_require = [
 
 
 setup(name='tokenserver',
-      version='1.4.5',
+      version='1.5.0',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,


### PR DESCRIPTION
We ain't exactly semver in here, but since this includes the significant new feature of [tracking keys_changed_at timestamps](https://github.com/mozilla-services/tokenserver/issues/124), it seemed appropriate to rev the minor version number.