### PR TITLE
Update README so "how to run the server" actually works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ In practice today, it is only used for connecting to Firefox Sync.
 
 Like this:
 
-    $ bin/paster serve etc/tokenserver-dev.ini
+    $ make install
+    $ ./local/bin/pip install gunicorn
+    $ ./local/bin/gunicorn --paste etc/tokenserver-dev.ini
 
 ## API
 

--- a/etc/tokenserver-dev.ini
+++ b/etc/tokenserver-dev.ini
@@ -16,7 +16,7 @@ service_entry = https://example.com
 sync-1.5 = {node}/1.5/{uid}
 
 [browserid]
-backend = tokenserver.verifiers.LocalBrowseridVerifier
+backend = tokenserver.verifiers.LocalBrowserIdVerifier
 audiences = https://token.services.mozilla.com
             
 # Paster configuration for Pyramid


### PR DESCRIPTION
This instructions didn't work, so I fixed 'em up so they do.