### PR TITLE
Adjust schemas.py to reflect state of DB after migration scripts.

### DIFF
--- a/tokenserver/assignment/sqlnode/schemas.py
+++ b/tokenserver/assignment/sqlnode/schemas.py
@@ -44,12 +44,12 @@ class _UsersBase(object):
                  nullable=False)
     service = Column(Integer(), nullable=False)
     email = Column(String(255), nullable=False)
-    nodeid = Column(BigInteger(), nullable=True)
     generation = Column(BigInteger(), nullable=False)
-    keys_changed_at = Column(BigInteger(), nullable=True)
     client_state = Column(String(32), nullable=False)
     created_at = Column(BigInteger(), nullable=False)
     replaced_at = Column(BigInteger(), nullable=True)
+    nodeid = Column(BigInteger(), nullable=False)
+    keys_changed_at = Column(BigInteger(), nullable=True)
 
     @declared_attr
     def __table_args__(cls):
@@ -60,7 +60,7 @@ class _UsersBase(object):
             # Index used for purging user_records that have been replaced.
             Index('replaced_at_idx', 'service', 'replaced_at'),
             # Index used for looking up all assignments on a node.
-            Index('node_idx', 'service', 'nodeid'),
+            Index('node_idx', 'nodeid'),
             {'mysql_engine': 'InnoDB', 'mysql_charset': 'utf8'}
         )
 


### PR DESCRIPTION
Commit 71a590f85a27eff6ee4cddfe25aaeb33d210baa2 appears to have introduced a subtle difference between the schema declared in `schemas.py` and the one that would be produced by running all our migrations in order.  It added a migration making `nodeid` non-nullable and adding an index on `nodeid`, but updated the schema to make `nodeid` nullable and add an index on the
pair (`service`, `nodeid`).

This commit fixes the schema to match what's in the database in production. For good measure I have also re-ordered the columns to match the order they physically appear in the database in production.  With this change, a db re-created from scratch using the declarations in `schemas.py` should end up being the same shape as in prod.