### PR TITLE
Correctly write keys_changed_at when it's the only updated field.

### DIFF
--- a/tokenserver/assignment/sqlnode/sql.py
+++ b/tokenserver/assignment/sqlnode/sql.py
@@ -324,7 +324,7 @@ class SQLNodeAssignment(object):
 
     def update_user(self, service, user, generation=None, client_state=None,
                     keys_changed_at=None, node=None):
-        if client_state is None and node is None:
+        if client_state is None and node is None and keys_changed_at is None:
             # We're just updating the generation, re-use the existing record.
             if generation is not None:
                 params = {

--- a/tokenserver/tests/test_backend_sql.py
+++ b/tokenserver/tests/test_backend_sql.py
@@ -29,8 +29,8 @@ class TestSQLBackend(unittest.TestCase):
         self.backend = self.config.registry.getUtility(INodeAssignment)
 
         # adding a service and a node with 100 slots
-        self.backend.add_service("sync-1.0", "{node}/{version}/{uid}")
-        self.backend.add_node("sync-1.0", "https://phx12", 100)
+        self.backend.add_service("sync-1.1", "{node}/1.1/{uid}")
+        self.backend.add_node("sync-1.1", "https://phx12", 100)
 
         self._sqlite = self.backend._engine.driver == 'pysqlite'
         endpoints = {}
@@ -48,18 +48,18 @@ class TestSQLBackend(unittest.TestCase):
             self.backend._safe_execute('delete from users')
 
     def test_get_node(self):
-        user = self.backend.get_user("sync-1.0", "test1@example.com")
+        user = self.backend.get_user("sync-1.1", "test1@example.com")
         self.assertEquals(user, None)
 
-        user = self.backend.allocate_user("sync-1.0", "test1@example.com")
+        user = self.backend.allocate_user("sync-1.1", "test1@example.com")
         self.assertEqual(user['email'], "test1@example.com")
         self.assertEqual(user['node'], "https://phx12")
 
-        user = self.backend.get_user("sync-1.0", "test1@example.com")
+        user = self.backend.get_user("sync-1.1", "test1@example.com")
         self.assertEqual(user['email'], "test1@example.com")
         self.assertEqual(user['node'], "https://phx12")
 
     def test_get_patterns(self):
         # patterns should have been populated
         patterns = get_current_registry()['endpoints_patterns']
-        self.assertDictEqual(patterns, {'sync-1.0': '{node}/{version}/{uid}'})
+        self.assertDictEqual(patterns, {'sync-1.1': '{node}/1.1/{uid}'})

--- a/tokenserver/tests/test_process_account_events.py
+++ b/tokenserver/tests/test_process_account_events.py
@@ -15,7 +15,8 @@ from tokenserver.scripts.process_account_events import process_account_event
 from tokenserver.assignment import INodeAssignment
 
 
-SERVICE = "sync-1.0"
+SERVICE = "sync-1.1"
+PATTERN = "{node}/1.1/{uid}"
 EMAIL = "test@example.com"
 UID = "test"
 ISS = "example.com"
@@ -41,7 +42,7 @@ class TestProcessAccountEvents(unittest.TestCase):
         self.config.include("tokenserver")
         load_and_register("tokenserver", self.config)
         self.backend = self.config.registry.getUtility(INodeAssignment)
-        self.backend.add_service(SERVICE, "{node}/{version}/{uid}")
+        self.backend.add_service(SERVICE, PATTERN)
         self.backend.add_node(SERVICE, "https://phx12", 100)
         self.logs = LogCapture()
 

--- a/tokenserver/tests/test_purge_old_records.py
+++ b/tokenserver/tests/test_purge_old_records.py
@@ -52,8 +52,8 @@ class TestPurgeOldRecordsScript(unittest.TestCase):
 
         # Configure the node-assignment backend to talk to our test service.
         self.backend = self.config.registry.getUtility(INodeAssignment)
-        self.backend.add_service("test-1.0", "{node}/1.0/{uid}")
-        self.backend.add_node("test-1.0", self.service_node, 100)
+        self.backend.add_service("sync-1.1", "{node}/1.1/{uid}")
+        self.backend.add_node("sync-1.1", self.service_node, 100)
 
     def tearDown(self):
         if self.backend._engine.driver == 'pysqlite':
@@ -80,7 +80,7 @@ class TestPurgeOldRecordsScript(unittest.TestCase):
 
     def test_purging_of_old_user_records(self):
         # Make some old user records.
-        service = "test-1.0"
+        service = "sync-1.1"
         email = "test@mozilla.com"
         user = self.backend.allocate_user(service, email, client_state="aa",
                                           generation=123)
@@ -113,7 +113,7 @@ class TestPurgeOldRecordsScript(unittest.TestCase):
         for i, environ in enumerate(self.service_requests):
             # They must be to the correct path.
             self.assertEquals(environ["REQUEST_METHOD"], "DELETE")
-            self.assertTrue(re.match("/1.0/[0-9]+", environ["PATH_INFO"]))
+            self.assertTrue(re.match("/1.1/[0-9]+", environ["PATH_INFO"]))
             # They must have a correct request signature.
             token = hawkauthlib.get_id(environ)
             secret = tokenlib.get_derived_secret(token, secret=node_secret)
@@ -131,7 +131,7 @@ class TestPurgeOldRecordsScript(unittest.TestCase):
 
     def test_purging_is_not_done_on_downed_nodes(self):
         # Make some old user records.
-        service = "test-1.0"
+        service = "sync-1.1"
         email = "test@mozilla.com"
         user = self.backend.allocate_user(service, email, client_state="aa")
         self.backend.update_user(service, user, client_state="bb")

--- a/tokenserver/tests/test_sql.ini
+++ b/tokenserver/tests/test_sql.ini
@@ -8,9 +8,24 @@ debug = true
 backend = tokenserver.assignment.sqlnode.SQLNodeAssignment
 sqluri = ${MOZSVC_SQLURI}
 create_tables = true
+applications = sync-1.1, sync-1.5
+token_duration = 3600
 secrets.backend = mozsvc.secrets.DerivedSecrets
 secrets.master_secrets = "abcdef"
                          "123456"
+
+[endpoints]
+sync-1.1 = {node}/1.1/{uid}
+
+[browserid]
+backend = tokenserver.verifiers.RemoteBrowserIdVerifier
+audiences = http://tokenserver.services.mozilla.com
+
+[oauth]
+backend = tokenserver.verifiers.RemoteOAuthVerifier
+
+[fxa]
+metrics_uid_secret_key = 'super-sekrit'
 
 # Paster configuration for Pyramid
 [filter:catcherror]


### PR DESCRIPTION
In the SQL backend, when updating a user's details, we try to do an in-place update rather than a replacement when the generation number is the only field that has changed.

Due to a bug, this branch was being taken even if the `keys_changed_at` field has changed, with the result being that the new `keys_changed_at` value just gets dropped on the floor.  This showed up in QA of the v1.5.0 release, when I tried to test against a user that already exists in the db.

The first commit here fixes the above bug, and is pretty trivial.

Unfortunately, I wasn't able to reproduce the bug in tests here, because most of the service API tests are only run against the memory backend, which didn't have the bug! I've therefore added a second commit here, which tries to ensure that these also get run against the SQL backend.  This would have caught the bug in CI if we'd had it previously.

To make this work, I had to modify `test_sql.ini` to more closely match `test_memorynode.ini`, which meant I had to tweak the details in several unrelated tests. So there's a surprisingly amount of churn here sorry, but it's only in incidental details like the names of services used in different tests.

