### PR TITLE
Don't force a node-reassigment when recording a new value of keys_changed_at

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ tests_require = [
 
 
 setup(name='tokenserver',
-      version='1.5.2',
+      version='1.5.3',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ tests_require = [
 
 
 setup(name='tokenserver',
-      version='1.5.1',
+      version='1.5.2',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,

--- a/tokenserver/assignment/memorynode.py
+++ b/tokenserver/assignment/memorynode.py
@@ -34,7 +34,10 @@ class MemoryNodeAssignmentBackend(object):
         self._next_uid = 1
 
     def get_user(self, service, email):
-        return self._users.get((service, email), None)
+        try:
+            return self._users[(service, email)].copy()
+        except KeyError:
+            return None
 
     def allocate_user(self, service, email, generation=0, client_state='',
                       keys_changed_at=0, node=None):
@@ -54,7 +57,7 @@ class MemoryNodeAssignmentBackend(object):
         }
         self._users[(service, email)] = user
         self._next_uid += 1
-        return user
+        return user.copy()
 
     def update_user(self, service, user, generation=None, client_state=None,
                     keys_changed_at=None, node=None):
@@ -71,3 +74,4 @@ class MemoryNodeAssignmentBackend(object):
             user['client_state'] = client_state
             user['uid'] = self._next_uid
             self._next_uid += 1
+        self._users[(service, user['email'])].update(user)

--- a/tokenserver/assignment/sqlnode/sql.py
+++ b/tokenserver/assignment/sqlnode/sql.py
@@ -64,15 +64,22 @@ values
      :timestamp, NULL)
 """)
 
-
-_UPDATE_GENERATION_NUMBER = sqltext("""\
+# The `where` clause on this statement is designed as an extra layer of protection,
+# to ensure that concurrent updates don't accidentally move timestamp fields
+# backwards in time. The handling of `keys_changed_at` is additionally weird because
+# we want to treat the defalut `NULL` value as zero.
+_UPDATE_USER_RECORD_IN_PLACE = sqltext("""\
 update
     users
 set
-    generation = :generation
+    generation = COALESCE(:generation, generation),
+    keys_changed_at = COALESCE(:keys_changed_at, keys_changed_at)
 where
     service = :service and email = :email and
-    generation < :generation and replaced_at is null
+    generation <= COALESCE(:generation, generation) and
+    COALESCE(keys_changed_at, 0) <=
+        COALESCE(:keys_changed_at, keys_changed_at, 0) and
+    replaced_at is null
 """)
 
 
@@ -324,17 +331,22 @@ class SQLNodeAssignment(object):
 
     def update_user(self, service, user, generation=None, client_state=None,
                     keys_changed_at=None, node=None):
-        if client_state is None and node is None and keys_changed_at is None:
-            # We're just updating the generation, re-use the existing record.
-            if generation is not None:
-                params = {
-                    'service': service,
-                    'email': user['email'],
-                    'generation': generation
-                }
-                res = self._safe_execute(_UPDATE_GENERATION_NUMBER, **params)
-                res.close()
-                user['generation'] = max(generation, user['generation'])
+        if client_state is None and node is None:
+            # No need for a node-reassignment, just update the row in place.
+            # Note that if we're changing keys_changed_at without changing
+            # client_state, it's because we're seeing an existing value of
+            # keys_changed_at for the first time.
+            params = {
+                'service': service,
+                'email': user['email'],
+                'generation': generation,
+                'keys_changed_at': keys_changed_at,
+            }
+            res = self._safe_execute(_UPDATE_USER_RECORD_IN_PLACE, **params)
+            res.close()
+            user['generation'] = max(generation, user['generation'])
+            user['keys_changed_at'] = max(keys_changed_at,
+                                          user['keys_changed_at'])
         else:
             # Reject previously-seen client-state strings.
             if client_state is None:

--- a/tokenserver/assignment/sqlnode/sql.py
+++ b/tokenserver/assignment/sqlnode/sql.py
@@ -64,10 +64,11 @@ values
      :timestamp, NULL)
 """)
 
-# The `where` clause on this statement is designed as an extra layer of protection,
-# to ensure that concurrent updates don't accidentally move timestamp fields
-# backwards in time. The handling of `keys_changed_at` is additionally weird because
-# we want to treat the defalut `NULL` value as zero.
+# The `where` clause on this statement is designed as an extra layer of
+# protection, to ensure that concurrent updates don't accidentally move
+# timestamp fields backwards in time. The handling of `keys_changed_at`
+# is additionally weird because we want to treat the defalut `NULL` value
+# as zero.
 _UPDATE_USER_RECORD_IN_PLACE = sqltext("""\
 update
     users


### PR DESCRIPTION
During the initial rollout of keys_changed_at, we may be in a situation where the tokenserver first sees a new value for keys_changed_at after some older version of the server has already processed the node-reassignment for the corresponding change in client_state. We don't want to force users through
another node-reassignment in that case, since they would already have done one.

This changes the sql backend to only force a node-reassignment when client_state changes, and adds some tests to ensure it. The memory backend was accidentally doing the right thing already, although the tests uncovered an issue with handing out mutable references to its internal state that I've had to fix as part of this PR.