### PR TITLE
Some suggestions for simplifying config handling in #163

### DIFF
--- a/etc/tokenserver-dev.ini
+++ b/etc/tokenserver-dev.ini
@@ -9,11 +9,8 @@ backend = tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend
 applications = sync-1.5
 secrets_file = tokenserver/tests/secrets
 service_entry = https://example.com
-spanner_entry  = https://spanner.example.com
-spanner_node_id = 800
 # this can be used to lock down the system to only existing accounts
 #allow_new_users = true
-migrate_new_user_percentage=0
 
 [endpoints]
 sync-1.5 = {node}/1.5/{uid}

--- a/tokenserver/assignment/__init__.py
+++ b/tokenserver/assignment/__init__.py
@@ -4,11 +4,6 @@ from zope.interface import Interface
 class INodeAssignment(Interface):
     """Interface definition for backend node-assignment db."""
 
-    def should_allocate_to_spanner(self, email):
-        """Determine if this user is routed to spanner
-
-        """
-
     def get_user(self, service, email):
         """Returns the user record for the given service and email.
 

--- a/tokenserver/tests/assignment/test_sqlnode.py
+++ b/tokenserver/tests/assignment/test_sqlnode.py
@@ -28,13 +28,8 @@ class NodeAssignmentTests(object):
         self.backend.add_service('sync-1.0', '{node}/1.0/{uid}')
         self.backend.add_service('sync-1.5', '{node}/1.5/{uid}')
         self.backend.add_service('queuey-1.0', '{node}/{service}/{uid}')
-        self.backend.add_service('spanner',
-                                 'https://spanner.example.com/1.5/{uid}')
         self.backend.add_node('sync-1.0', 'https://phx12', 100)
         self.backend.add_node('sync-1.5', 'https://phx11', 100)
-        self.backend.add_node('spanner',
-                              'https://spanner.example.com/1.5/{uid}', 9000)
-        self.backend._migrate_new_user_percentage = 0
 
     def test_node_allocation(self):
         user = self.backend.get_user("sync-1.0", "test1@example.com")

--- a/tokenserver/tests/test_memorynode.ini
+++ b/tokenserver/tests/test_memorynode.ini
@@ -13,9 +13,6 @@ node = https://example.com
 token_duration = 3600
 node_type_patterns =
   example:*example*
-spanner_entry  = https://spanner.example.com
-spanner_node_id = 800
-migrate_new_user_percentage=0
 
 [endpoints]
 sync-1.1 = {node}/1.1/{uid}

--- a/tokenserver/tests/test_service.py
+++ b/tokenserver/tests/test_service.py
@@ -791,23 +791,6 @@ class TestService(unittest.TestCase):
         res = self.app.get('/1.0/sync/1.1', headers=headers, status=200)
         self.assertEqual(res.json['node_type'], 'example')
 
-    def test_migrate_new_user(self):
-        EMAIL0 = "abO-test@example.com"
-        EMAIL1 = "abT-test@example.com"
-        self.backend._test_settings['migrate_new_user_percentage'] = 1
-        settings = self.backend.settings
-
-        user0 = self.backend.allocate_user("sync-1.5", EMAIL0)
-        user1 = self.backend.allocate_user("sync-1.5", EMAIL1)
-        self.assertEquals(
-            user0['node'],
-            settings['spanner_entry'])
-        self.assertEquals(
-            user1['node'],
-            settings.get('service_entry', 'https://phx11'))
-
-        del(self.backend._settings['migrate_new_user_percentage'])
-
 
 class TestServiceWithSQLBackend(TestService):
 
@@ -824,16 +807,29 @@ class TestServiceWithSQLBackend(TestService):
         # Ensure the necessary service exists in the db.
         self.backend.add_service('sync-1.1', '{node}/1.1/{uid}')
         self.backend.add_service('sync-1.5', '{node}/1.5/{uid}')
-        # while stand alone mysql dbs will not hava a "spanner" service
-        # the unified test suite will fail if a "spanner" service is not
-        # defined.
-        self.backend.add_service(
-            'spanner', 'https://spanner.example.com/1.5/{uid}')
         # Ensure we have a node with enough capacity to run the tests.
         self.backend.add_node('sync-1.1', 'https://example.com', 100)
-        self.backend.add_node('sync-1.5', 'https://phx11', 100)
-        self.backend.add_node('spanner',
-                              'https://spanner.example.com/1.5/{uid}', 9000)
+        self.backend.add_node('sync-1.5', 'https://example.com', 100)
+        # Ensure that we have a spanner node, but give it no capacity
+        # so that users are not assigned it except under special circumstances.
+        self.backend.add_node('sync-1.5', 'https://spanner.example.com', 0,
+                              nodeid=800)
+
+    def test_assign_new_users_to_spanner(self):
+        # The .ini file sets migrate_new_user_percentage=1, and these
+        # emails are carefully selected so that the first one will be
+        # assigned to the spanner node but the second one will not.
+        EMAIL0 = "abO-test@example.com"
+        EMAIL1 = "abT-test@example.com"
+
+        user0 = self.backend.allocate_user("sync-1.5", EMAIL0)
+        user1 = self.backend.allocate_user("sync-1.5", EMAIL1)
+        self.assertEquals(
+            user0['node'],
+            'https://spanner.example.com')
+        self.assertEqual(
+            user1['node'],
+            'https://example.com')
 
     def tearDown(self):
         # And clean up at the end, for good measure.

--- a/tokenserver/tests/test_sql.ini
+++ b/tokenserver/tests/test_sql.ini
@@ -15,9 +15,8 @@ secrets.master_secrets = "abcdef"
                          "123456"
 node_type_patterns =
   example:*example.com
-spanner_entry  = https://spanner.example.com
 spanner_node_id = 800
-migrate_new_user_percentage=0
+migrate_new_user_percentage=1
 
 [endpoints]
 sync-1.1 = {node}/1.1/{uid}


### PR DESCRIPTION
@jrconlin I was puzzled by https://github.com/mozilla-services/tokenserver/pull/163#discussion_r361885306 so decided to dig in a bit and see what was going on. In the process I came to the opinion that you shouldn't need to add spanner handling to the `MemoryNodeAssignmentBackend` at all - the whole premise of that backend is that it's a very simple setup where everyone is on a single node, and adding the complexity of a new second node doesn't seem to provide us any value. I don't think anyone would ever actually use it.

So...here's a proposal to simplify the config handling in #163, by removing spanner from the memory backend and configuring it exclusively via `**kw` in the sql backend. I also rejiggered some tests around to match.

Please feel free to take it or leave it, but I wanted to get my head around what was happening with all the config, and the easiest way to do that was with code.