### PR TITLE
feat: add dynamic_settings table for on-the-fly ops config

### DIFF
--- a/tokenserver/assignment/sqlnode/migrations/versions/5d056c5b8f57_create_dyn_settings_table.py
+++ b/tokenserver/assignment/sqlnode/migrations/versions/5d056c5b8f57_create_dyn_settings_table.py
@@ -5,13 +5,12 @@ Revises: 75e8ca84b0bc
 Create Date: 2020-01-06 08:16:15.546054
 
 """
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '5d056c5b8f57'
 down_revision = '75e8ca84b0bc'
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/tokenserver/assignment/sqlnode/migrations/versions/5d056c5b8f57_create_dyn_settings_table.py
+++ b/tokenserver/assignment/sqlnode/migrations/versions/5d056c5b8f57_create_dyn_settings_table.py
@@ -1,0 +1,28 @@
+"""create dyn_settings table
+
+Revision ID: 5d056c5b8f57
+Revises: 75e8ca84b0bc
+Create Date: 2020-01-06 08:16:15.546054
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5d056c5b8f57'
+down_revision = '75e8ca84b0bc'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'dynamic_settings',
+        sa.Column('setting', sa.String(100), primary_key=True),
+        sa.Column('value', sa.String(255), nullable=False),
+        sa.Column('description', sa.String(255))
+    )
+
+
+def downgrade():
+    op.drop_table('dynamic_settings')
+    pass

--- a/tokenserver/assignment/sqlnode/schemas.py
+++ b/tokenserver/assignment/sqlnode/schemas.py
@@ -116,3 +116,17 @@ class _NodesBase(object):
 
 
 _add('nodes', _NodesBase)
+
+
+class _SettingsBase(object):
+    """This table holds dynamic setting values for operations.
+
+    Really, only useful for longer lived SQL nodes right now.
+
+    """
+    setting = Column(String(100), primary_key=True, nullable=False)
+    value = Column(String(255), nullable=False)
+    description = Column(String(255), nullable=True)
+
+
+_add('dynamic_settings', _SettingsBase)

--- a/tokenserver/assignment/sqlnode/sql.py
+++ b/tokenserver/assignment/sqlnode/sql.py
@@ -11,6 +11,7 @@ with their load, capacity etc
 import math
 import traceback
 import hashlib
+import time
 from mozsvc.exceptions import BackendError
 
 from sqlalchemy.sql import select, update, and_
@@ -182,6 +183,16 @@ where
 """)
 
 
+_GET_DYNAMIC_SETTING = sqltext("""
+select
+    value
+from
+    dynamic_settings
+where
+    setting = :setting
+""")
+
+
 class SQLNodeAssignment(object):
 
     implements(INodeAssignment)
@@ -192,6 +203,7 @@ class SQLNodeAssignment(object):
                  spanner_node_id=None, migrate_new_user_percentage=0,
                  **kw):
         self._cached_service_ids = {}
+        self._cache_migration_ttl = 0
         self.sqluri = sqluri
         if pool_reset_on_return.lower() in ('', 'none'):
             pool_reset_on_return = None
@@ -234,8 +246,10 @@ class SQLNodeAssignment(object):
         self.services = get_cls('services', _Base)
         self.nodes = get_cls('nodes', _Base)
         self.users = get_cls('users', _Base)
+        self.dyn_settings = get_cls('dynamic_settings', _Base)
 
-        for table in (self.services, self.nodes, self.users):
+        for table in (self.services, self.nodes,
+                      self.users, self.dyn_settings):
             table.metadata.bind = self._engine
             if create_tables:
                 table.create(checkfirst=True)
@@ -314,13 +328,35 @@ class SQLNodeAssignment(object):
         finally:
             res.close()
 
+    def get_migration_percent(self):
+        """get a cached Ops controllable percentage value for the number of
+        new users to migrate to Spanner."""
+        if self._cache_migration_ttl > time.time():
+            return self.migrate_new_user_percentage
+        default = self.migrate_new_user_percentage or 0
+        try:
+            res = self._safe_execute(
+                _GET_DYNAMIC_SETTING,
+                {"setting": "migrate_new_user_percentage"})
+            self.migrate_new_user_percentage = (
+                int(res.fetchone()[0]) or default
+            )
+            self._cache_migration_ttl = time.time() + 300
+        except Exception as ex:
+            logger.info(
+                "Could not get migration percent \"{}\" using default: {}"
+                .format(ex, default)
+            )
+        return self.migrate_new_user_percentage
+
     def should_allocate_to_spanner(self, email):
         """use a simple, reproducable hashing mechanism to determine if
         a user should be provisioned to spanner. Does not need to be
         secure, just a selectable percentage."""
-        if self.migrate_new_user_percentage:
+        migrate = self.get_migration_percent()
+        if migrate:
             pick = ord(hashlib.sha1(email.encode()).digest()[0])
-            return pick < (256 * (self.migrate_new_user_percentage * .01))
+            return pick < (256 * (migrate * .01))
         else:
             return False
 

--- a/tokenserver/assignment/sqlnode/sqliteschemas.py
+++ b/tokenserver/assignment/sqlnode/sqliteschemas.py
@@ -6,8 +6,10 @@
 """
 from tokenserver.assignment.sqlnode.schemas import (_UsersBase,
                                                     _NodesBase,
+                                                    _SettingsBase,
                                                     Integer,
                                                     Column,
+                                                    String,
                                                     _add,
                                                     declared_attr)
 
@@ -37,3 +39,14 @@ class _SQLITEUsersBase(_UsersBase):
 
 
 _add('users', _SQLITEUsersBase)
+
+
+class _SQLITESettingsBase(_SettingsBase):
+    setting = Column(String(100), primary_key=True)
+
+    @declared_attr
+    def __table_args__(cls):
+        return()
+
+
+_add('dynamic_settings', _SQLITESettingsBase)


### PR DESCRIPTION
Allows ops to modify `dynamic_settings` `migrate_new_user_percentage`
without requiring a redeployment.

Closes #165