### PR TITLE
purge_old_records: add --max-offset option and some additional logging statements

### DIFF
--- a/tokenserver/assignment/sqlnode/sql.py
+++ b/tokenserver/assignment/sqlnode/sql.py
@@ -124,6 +124,8 @@ order by
     replaced_at desc, uid desc
 limit
     :limit
+offset
+    :offset
 """)
 
 
@@ -454,7 +456,8 @@ class SQLNodeAssignment(object):
         finally:
             res.close()
 
-    def get_old_user_records(self, service, grace_period=-1, limit=100):
+    def get_old_user_records(self, service, grace_period=-1, limit=100,
+                             offset=0):
         """Get user records that were replaced outside the grace period."""
         if grace_period < 0:
             grace_period = 60 * 60 * 24 * 7  # one week, in seconds
@@ -463,6 +466,7 @@ class SQLNodeAssignment(object):
             "service": service,
             "timestamp": get_timestamp() - grace_period,
             "limit": limit,
+            "offset": offset
         }
         res = self._safe_execute(_GET_OLD_USER_RECORDS_FOR_SERVICE, **params)
         try:

--- a/tokenserver/tests/assignment/test_sqlnode.py
+++ b/tokenserver/tests/assignment/test_sqlnode.py
@@ -175,6 +175,10 @@ class NodeAssignmentTests(object):
         # That should be a total of 7 old records.
         old_records = list(self.backend.get_old_user_records(service, 0))
         self.assertEqual(len(old_records), 7)
+        # And with max_offset of 3, the first record should be id 4
+        old_records = list(self.backend.get_old_user_records(service, 0,
+                                                             100, 3))
+        self.assertEqual(old_records[0][0], 4)
         # The 'limit' parameter should be respected.
         old_records = list(self.backend.get_old_user_records(service, 0, 2))
         self.assertEqual(len(old_records), 2)


### PR DESCRIPTION
r? - @rfk

I was working with the purge task in production to get it to run more effectively, and noticed a couple of things.

1. the default max-per-loop of 10 meant that each task was spending a large chunk of each cycle doing the select, and spinning a lot of database cpu. So I'll be using a max-per-loop of ~1000 going forward.

2. Due to the current select for old_records, each purge task winds up working on the same set of old_records. So this PR adds a --max-offset option to the task. The idea is that if each instance's task picks a random offset < max_offset, then it will be unlikely to have any 2 instances working on the same set of records. I'm thinking of running something like max-per-loop=1000 and max-offset=100000. The offset will add some additional cost to each select, so I'll have to play with those numbers to get the right tradeoff. But one thing I'm unclear about: the current query does `order by replaced_at desc, uid desc`. Is there some importance to that ordering? I.e., if I'm skipping to the middle of that list with an offset does that break some expectation?

This PR also adds a couple of logging statements I was interested in being able to see.

(Note: one gotcha with `--max-offset` is that if the number of purgeable rows is << max_offset, then **no** rows will be purged. I didn't try to defend against that in this PR. When the backlog is down to a manageable level I'll change max_offset to be zero (or maybe 10000 to keep a little bit of scatter). Or maybe not change it all: enough instances will get work to do by chance to keep to backlog under control).