### PR TITLE
get_old_user_records: restrict result set to exclude downed nodes

### DIFF
--- a/tokenserver/scripts/purge_old_records.py
+++ b/tokenserver/scripts/purge_old_records.py
@@ -64,7 +64,8 @@ def purge_old_records(config_file, grace_period=-1, max_per_loop=10,
                     "limit": max_per_loop,
                     "offset": offset,
                 }
-                rows = list(backend.get_old_user_records(service, **kwds))
+                rows = backend.get_old_user_records_to_purge(service, **kwds)
+                rows = list(rows)
                 logger.info("Fetched %d rows at offset %d", len(rows), offset)
                 for row in rows:
                     # Don't attempt to purge data from downed nodes.


### PR DESCRIPTION
fixes #170 r? - @rfk 

Narrows the result set to exclude downed nodes; gives an index hint to mysql to choose an efficient plan (thanks again for the pointer).

This produces this query (mildly reformatted for readability) in stage, which can be compared to what `_GET_OLD_USER_RECORDS_FOR_SERVICE` produced:
```
SELECT
    users.uid, users.email, users.generation, users.keys_changed_at, users.client_state,
    nodes.node, nodes.downed, users.created_at, users.replaced_at
FROM users
USE INDEX (replaced_at_idx)
LEFT OUTER JOIN nodes ON users.nodeid = nodes.id
WHERE
    users.service = 1
AND
    coalesce(nodes.downed, 0) != 1
AND
    users.replaced_at IS NOT NULL
AND
    users.replaced_at < 1579578375708
ORDER BY users.replaced_at DESC, users.uid DESC
LIMIT 70072, 1000
```
The `coalesce(nodes.downed, 0) != 1` is to deal with the fact that `downed` on rows can be 0, 1 or NULL; this keeps the same semantics of `get_old_user_records`, which one existing test revealed.

Perhaps more tests could be added, but another existing test mostly covers the check that downed nodes are never removed, before or after this PR.