### PR TITLE
Rename `get_old_user_records` to `get_old_user_records_purge`.

### DIFF
--- a/tokenserver/scripts/purge_old_records.py
+++ b/tokenserver/scripts/purge_old_records.py
@@ -64,7 +64,8 @@ def purge_old_records(config_file, grace_period=-1, max_per_loop=10,
                     "limit": max_per_loop,
                     "offset": offset,
                 }
-                rows = list(backend.get_old_user_records(service, **kwds))
+                rows = backend.get_old_user_records_to_purge(service, **kwds)
+                rows = list(rows)
                 logger.info("Fetched %d rows at offset %d", len(rows), offset)
                 for row in rows:
                     # Don't attempt to purge data from downed nodes.


### PR DESCRIPTION
Future me will not remember the details of why downed nodes are excluded from `get_old_user_records`; this renames it to more fully describe what the result should be used for and adds some docs about it. @jrgm r?