### PR TITLE
fix: remember keys_changed_at when reallocating after node replacement.

### DIFF
--- a/tokenserver/assignment/sqlnode/sql.py
+++ b/tokenserver/assignment/sqlnode/sql.py
@@ -316,7 +316,8 @@ class SQLNodeAssignment(object):
                 if cur_row.generation < MAX_GENERATION:
                     user = self.allocate_user(service, email,
                                               cur_row.generation,
-                                              cur_row.client_state)
+                                              cur_row.client_state,
+                                              cur_row.keys_changed_at)
             for old_row in old_rows:
                 # Collect any previously-seen client-state values.
                 if old_row.client_state != user['client_state']:

--- a/tokenserver/tests/assignment/test_sqlnode.py
+++ b/tokenserver/tests/assignment/test_sqlnode.py
@@ -197,12 +197,17 @@ class NodeAssignmentTests(object):
 
     def test_node_reassignment_when_records_are_replaced(self):
         self.backend.allocate_user("sync-1.0", "test@mozilla.com",
-                                   generation=42, client_state="aaa")
+                                   generation=42,
+                                   keys_changed_at=12,
+                                   client_state="aaa")
         user1 = self.backend.get_user("sync-1.0", "test@mozilla.com")
         self.backend.replace_user_records("sync-1.0", "test@mozilla.com")
         user2 = self.backend.get_user("sync-1.0", "test@mozilla.com")
+        # They should have got a new uid.
         self.assertNotEqual(user2["uid"], user1["uid"])
+        # But their account metadata should have been preserved.
         self.assertEqual(user2["generation"], user1["generation"])
+        self.assertEqual(user2["keys_changed_at"], user1["keys_changed_at"])
         self.assertEqual(user2["client_state"], user1["client_state"])
 
     def test_node_reassignment_not_done_for_retired_users(self):


### PR DESCRIPTION
If a user's current storage node is decomissioned, they may end up
without an active `users` record in the db, and there is code to
handle this case by lazily recreating an active record on demand.

Previously, this code would only copy `generation` and `client_state`
fields, essentially forgotten any previously-seen value for the new
`keys_changed_at` field. This commit fixes things so that value is
also remembered.

I do not expect this bug to have caused any issues in practice, since
we already have a bunch of code to handle users for which we have
not yet seen a value of `keys_changed_at`. But we should remember it
when we can because it helps the server enforce that clients are
behaving correctly.