### PR TITLE
Revisit some TODO items around keys_changed_at consistency checks.

### DIFF
--- a/tokenserver/tests/test_service.py
+++ b/tokenserver/tests/test_service.py
@@ -484,14 +484,13 @@ class TestService(unittest.TestCase):
             res = self.app.get('/1.0/sync/1.1', headers=headers)
         token = self.unsafelyParseToken(res.json["id"])
         self.assertEqual(token["fxa_kid"], "0000000002345-YmJi")
-        # TODO: ideally we will error if keysChangedAt changes without a
-        # change in generation, but we can't do that until all servers
-        # are running the latest version of the code.
-        # mock_response["idpClaims"]["fxa-keysChangedAt"] = 4567
-        # headers["X-Client-State"] = "636363"
-        # with self.mock_browserid_verifier(response=mock_response):
-        #     res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
-        # self.assertEqual(res.json["status"], "invalid-keysChangedAt")
+        # We should error out if keysChangedAt changes to be larger than
+        # the corresponding generation number.
+        mock_response["idpClaims"]["fxa-keysChangedAt"] = 4567
+        headers["X-Client-State"] = "636363"
+        with self.mock_browserid_verifier(response=mock_response):
+            res = self.app.get('/1.0/sync/1.1', headers=headers, status=401)
+        self.assertEqual(res.json["status"], "invalid-keysChangedAt")
         # But accept further updates if both values change in unison.
         mock_response["idpClaims"]["fxa-generation"] = 4567
         mock_response["idpClaims"]["fxa-keysChangedAt"] = 4567


### PR DESCRIPTION
Past-rfkelly helpfully left a `TODO` item in the code for checking consistency of `keys_changed_at`, which I went to revisit in light of [Bug 1613032](https://bugzilla.mozilla.org/show_bug.cgi?id=1613032).

Unfortunately for Past-rfkelly, his reasoning that we could add this check once all servers are running the latest code is not sound. There's a (very very small) chance that a user could have:

* Synced once against a new server, recording a `keys_changed_at` timestamp
* Reset their account password, then synced once against an older server during the rollout of the `keys_changed_at` feature, recording an updated `generation` but leaving the old `keys_changed_at`.
* Never synced again after that.

When this user suddenly comes back and syncs against a server with the proposed additional consistency checks, we would see an update to `keys_changed_at` but no corresponding update to `generation`, and incorrectly lock them out of their sync data.

I briefly toyed with the idea of adding a check that says "for records created after X date, ensure that a change to `keys_changed_at` is accompanied by a change to `generation`. But it seemed like too much effort for too little gain, so instead I have:

* Added some more documentation about the consistency relationships we actually expect to see between these values.
* Remove the "TODO" about adding more checks once all servers are deployed.
* Added a different, less restrictive check that ensures we never see a `keys_changed_at` that is outright ahead of the corresponding `generation`.