### PR TITLE
Fix #182: Update PyFxA and handle 'generation' fields in the oauth re…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ plaster==1.0
 plaster-pastedeploy==0.7
 PyBrowserID==0.14.0
 pycparser==2.19
-PyFxA==0.7.1
+PyFxA==0.7.4
 PyMySQL==0.9.3
 pymysql-sa==1.0
 pyramid==1.10.4
@@ -34,7 +34,7 @@ python-editor==1.0.4
 repoze.lru==0.7
 requests==2.22.0
 simplejson==3.16.0
-six==1.12.0
+six==1.14.0
 SQLAlchemy==1.3.3
 testfixtures==6.7.0
 tokenlib==2.0.0

--- a/tokenserver/tests/test_oauth_verifier.py
+++ b/tokenserver/tests/test_oauth_verifier.py
@@ -186,3 +186,14 @@ class TestRemoteOAuthVerifier(unittest.TestCase):
         with self._mock_verifier(verifier, response={"user": "UID"}):
             with self.assertRaises(fxa.errors.TrustError):
                 verifier.verify(MOCK_TOKEN)
+
+    @responses.activate
+    def test_verifier_returns_generation(self):
+        config = self._make_config()
+        verifier = config.registry.getUtility(IOAuthVerifier)
+        generation = 2
+        with self._mock_verifier(
+                verifier,
+                response={"user": "UID", "generation": generation}):
+            self.assertEquals(verifier.verify(MOCK_TOKEN)['idpClaims'].get(
+                'fxa-generation'), generation)

--- a/tokenserver/tests/test_service.py
+++ b/tokenserver/tests/test_service.py
@@ -842,7 +842,7 @@ class TestServiceWithNoBackends(unittest.TestCase):
         self.config = testing.setUp()
         self.config.add_settings({ # noqa; identation below is non-standard
             "tokenserver.backend":
-              "tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend",
+              "tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend", # noqa
             "tokenserver.secrets.backend":
               "mozsvc.secrets.FixedSecrets",
             "tokenserver.secrets.secrets":
@@ -885,7 +885,7 @@ class TestServiceWithNoBrowserID(unittest.TestCase):
         self.config = testing.setUp()
         self.config.add_settings({ # noqa; identation below is non-standard
             "tokenserver.backend":
-              "tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend",
+              "tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend", # noqa
             "tokenserver.secrets.backend":
               "mozsvc.secrets.FixedSecrets",
             "tokenserver.secrets.secrets":
@@ -934,7 +934,7 @@ class TestServiceWithNoOAuth(unittest.TestCase):
         self.config = testing.setUp()
         self.config.add_settings({ # noqa; identation below is non-standard
             "tokenserver.backend":
-              "tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend",
+              "tokenserver.assignment.memorynode.MemoryNodeAssignmentBackend", # noqa
             "tokenserver.secrets.backend":
               "mozsvc.secrets.FixedSecrets",
             "tokenserver.secrets.secrets":

--- a/tokenserver/verifiers.py
+++ b/tokenserver/verifiers.py
@@ -233,9 +233,12 @@ class RemoteOAuthVerifier(object):
         if not issuer or not isinstance(issuer, basestring):
             msg = 'Could not determine issuer from verifier response'
             raise fxa.errors.TrustError(msg)
+        idpclaims = {}
+        if userinfo.get('generation') is not None:
+            idpclaims['fxa-generation'] = userinfo['generation']
         return {
           'email': userinfo['user'] + '@' + issuer,
-          'idpClaims': {},
+          'idpClaims': idpclaims,
         }
 
 


### PR DESCRIPTION
…sponse; add a test to cover using the 'generation' field.