### PR TITLE
docker: check that entrypoints and gunicorn work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,24 @@ jobs:
       - run:
           name: Test nose
           command: docker run -it app:build test_nose
+      - run:
+          name: Test that the `python` entrypoint responds
+          command: |
+            set -e
+            docker run -it app:build python --version
+      - run:
+          name: Test that the `server` entrypoint starts ok
+          command: |
+            set -e
+            container_name=$(docker run -it -e MOZSVC_SQLURI="sqlite:////tmp/tokenserver.db" --rm -d app:build server)
+            # Grab the logs now in case this crashes and is removed.
+            (docker logs --follow $container_name &)
+            sleep 10
+            # If the container above stops before running 10 seconds, the
+            # `--rm` will remove it and this `docker inspect` will exit
+            # non-zero, failing this step.
+            docker inspect -f '{{.State.Running}}' $container_name
+            docker kill $container_name
       - store_test_results:
           path: test_results
       - run:


### PR DESCRIPTION
Check that the docker image can be used for production.

This PR currently fails due to the CFFI/gunicorn issue, but a passing circleci run can be seen on a branch based on 1.5.5 in https://app.circleci.com/pipelines/github/mozilla-services/tokenserver/31/workflows/aa2aef31-8c37-47c6-961e-fae777be130e/jobs/410

(A further improvement to this test would be to make it connect to a mysql URL, but for now go with a sqlite url).