### PR TITLE
fix: use cffi 1.13.2 because reasons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,24 @@ jobs:
       - run:
           name: Test nose
           command: docker run -it app:build test_nose
+      - run:
+          name: Test that the `python` entrypoint responds
+          command: |
+            set -e
+            docker run -it app:build python --version
+      - run:
+          name: Test that the `server` entrypoint starts ok
+          command: |
+            set -e
+            container_name=$(docker run -it -e MOZSVC_SQLURI="sqlite:////tmp/tokenserver.db" --rm -d app:build server)
+            # Grab the logs now in case this crashes and is removed.
+            (docker logs --follow $container_name &)
+            sleep 10
+            # If the container above stops before running 10 seconds, the
+            # `--rm` will remove it and this `docker inspect` will exit
+            # non-zero, failing this step.
+            docker inspect -f '{{.State.Running}}' $container_name
+            docker kill $container_name
       - store_test_results:
           path: test_results
       - run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==1.0.9
 asn1crypto==0.24.0
 boto==2.49.0
 certifi==2019.3.9
-cffi==1.12.2
+cffi==1.13.2
 chardet==3.0.4
 configparser==3.7.4
 cornice==3.5.1


### PR DESCRIPTION
I noticed this message go by in a failing build:
```
  Attempting uninstall: cffi
    Found existing installation: cffi 1.13.2
    Can't uninstall 'cffi'. No files were found to uninstall.
```

... and so I tried changing that in requirements.txt to match that version, and surprise, it "works".

This PR also includes the circle-ci test from https://github.com/mozilla-services/tokenserver/pull/188 and the `docker run app:build server` shows that it starts up there.

I put this on stage, and the tokenserver daemon starts up and runs. However the event processor job fails with `/usr/bin/python: No module named zope.interface` so more work to do, but I'm going to stop for now. 