### PR TITLE
fix: allow `pypy` in docker-entrypoint.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,16 +29,16 @@ jobs:
           name: Test nose
           command: docker run -it app:build test_nose
       - run:
-          name: Test that the `python` entrypoint responds
+          name: Test that the `pypy` entrypoint responds
           command: |
             set -e
-            docker run -it app:build python --version
+            docker run -it app:build pypy --version
       - run:
           name: Test that the `server` entrypoint starts ok
           command: |
             set -e
             container_name=$(docker run -it -e MOZSVC_SQLURI="sqlite:////tmp/tokenserver.db" --rm -d app:build server)
-            # Grab the logs now in case this crashes and is removed.
+            # Grab the logs now in case this container crashes and is removed.
             (docker logs --follow $container_name &)
             sleep 10
             # If the container above stops before running 10 seconds, the

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,7 +25,7 @@ case "$1" in
             --log-config "$_SETTINGS_FILE"
         ;;
 
-    python)
+    pypy)
         exec "$@"
         ;;
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==1.0.9
 asn1crypto==0.24.0
 boto==2.49.0
 certifi==2019.3.9
-cffi==1.13.2
+cffi==1.13.2 ; platform_python_implementation == "CPython"
 chardet==3.0.4
 configparser==3.7.4
 cornice==3.5.1


### PR DESCRIPTION
Allow `pypy` in docker-entrypoint.sh