### PR TITLE
Json jwks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ asn1crypto==0.24.0
 boto==2.49.0
 certifi==2019.3.9
 # Handle older cffi versions in circleci
-cffi==1.13.2; implementation_name=="pypy"
-cffi==1.14.0; implementation_name!="pypy"
+cffi==1.14.0; platform_python_implementation == "CPython"
 chardet==3.0.4
 configparser==3.7.4
 cornice==3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,9 @@ alembic==1.0.9
 asn1crypto==0.24.0
 boto==2.49.0
 certifi==2019.3.9
-cffi==1.14.0
+# Handle older cffi versions in circleci
+cffi==1.13.2; implementation_name=="pypy"
+cffi==1.14.0; implementation_name!="pypy"
 chardet==3.0.4
 configparser==3.7.4
 cornice==3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,14 @@ alembic==1.0.9
 asn1crypto==0.24.0
 boto==2.49.0
 certifi==2019.3.9
-cffi==1.13.2 ; platform_python_implementation == "CPython"
+cffi==1.14.0
 chardet==3.0.4
 configparser==3.7.4
 cornice==3.5.1
 cryptography==2.6.1
 enum34==1.1.6
 gevent==1.4.0
+greenlet==0.4.13
 gunicorn==19.10.0
 hawkauthlib==2.0.0
 hupper==1.6.1
@@ -26,11 +27,13 @@ plaster-pastedeploy==0.7
 PyBrowserID==0.14.0
 pycparser==2.19
 PyFxA==0.7.6
+PyJWT==1.7.1
 PyMySQL==0.9.3
 pymysql-sa==1.0
 pyramid==1.10.4
 python-dateutil==2.8.0
 python-editor==1.0.4
+readline==6.2.4.1
 repoze.lru==0.7
 requests==2.22.0
 simplejson==3.16.0

--- a/tokenserver/verifiers.py
+++ b/tokenserver/verifiers.py
@@ -191,6 +191,8 @@ class RemoteOAuthVerifier(object):
                  scope=DEFAULT_OAUTH_SCOPE, jwks=None):
         if not scope:
             raise ValueError('Expected a non-empty "scope" argument')
+        if jwks is not None:
+            jwks = json.loads(jwks)
         self._client = fxa.oauth.Client(server_url=server_url, jwks=jwks)
         self._client.timeout = timeout
         if default_issuer is None:

--- a/tokenserver/verifiers.py
+++ b/tokenserver/verifiers.py
@@ -192,7 +192,7 @@ class RemoteOAuthVerifier(object):
         if not scope:
             raise ValueError('Expected a non-empty "scope" argument')
         if jwks is not None:
-            jwks = json.loads(jwks)
+            jwks = json.loads(jwks.get('keys', []))
         self._client = fxa.oauth.Client(server_url=server_url, jwks=jwks)
         self._client.timeout = timeout
         if default_issuer is None:


### PR DESCRIPTION
Since Paste Deploy can only pass string configuration values and not a list, make the jwks configuration parameter a serialized json object with a 'keys' key which is a list of jwks keys.