### PR TITLE
Pin the version of `pip` used in the `pypy` virtualenv.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ help:
 all: install
 install: $(INSTALL_STAMP)
 $(INSTALL_STAMP): $(PYTHON) setup.py
-	$(INSTALL) -U pip
 	$(INSTALL) -Ue .
 	touch $(INSTALL_STAMP)
 
@@ -47,11 +46,14 @@ $(DEV_STAMP): $(PYTHON) dev-requirements.txt
 
 virtualenv: $(PYTHON)
 $(PYTHON):
-	$(VIRTUALENV) -p pypy $(VENV)
+	# The latest `pip` doesn't work with pypy 2.7 on some platforms.
+	# Pin to a working version; ref https://github.com/pypa/pip/issues/8653
+	$(VIRTUALENV) -p pypy --no-pip $(VENV)
+	$(VENV)/bin/easy_install pip==20.1.1
 
 build-requirements:
-	$(VIRTUALENV) $(TEMPDIR)
-	$(TEMPDIR)/bin/pip install -U pip
+	$(VIRTUALENV) -p pypy --no-pip $(TEMPDIR)
+	$(TEMPDIR)/bin/easy_install pip==20.1.1
 	ARCHFLAGS=$(ARCHFLAGS) $(TEMPDIR)/bin/pip install -Ue .
 	$(TEMPDIR)/bin/pip freeze | grep -v -- '^-e' > requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ pymysql-sa==1.0
 pyramid==1.10.4
 python-dateutil==2.8.0
 python-editor==1.0.4
-readline==6.2.4.1
 repoze.lru==0.7
 requests==2.22.0
 simplejson==3.16.0


### PR DESCRIPTION
Newer versions of `pip` do not work with `pypy` v2.7 on some platforms, ref https://github.com/pypa/pip/issues/8653