### PR TITLE
test: revert the test's responses package workaround

### DIFF
--- a/tokenserver/verifiers.py
+++ b/tokenserver/verifiers.py
@@ -207,21 +207,12 @@ class RemoteOAuthVerifier(object):
                     default_issuer = urlparse.urlparse(auth_url).netloc
                     break
             else:
+                # For non-standard hosting setups, look it up dynamically.
+                r = requests.get(server_url[:-3] + '/config')
+                r.raise_for_status()
                 try:
-                    # For non-standard hosting setups, look it up dynamically.
-                    r = requests.get(server_url[:-3] + '/config')
-                    r.raise_for_status()
-                    try:
-                        default_issuer = r.json()['browserid']['issuer']
-                    except KeyError:
-                        pass
-                except ValueError as e:
-                    # some tests fail because requests returns a ValueError
-                    # "I/O operation on a closed file"
-                    # this is because response fails to read the empty stream.
-                    # treat it as an empty response.
-                    import logging
-                    logging.getLogger().debug(e)
+                    default_issuer = r.json()['browserid']['issuer']
+                except KeyError:
                     pass
         self.default_issuer = default_issuer
         self.scope = scope


### PR DESCRIPTION
now that it's pinned to an old version to avoid the issue